### PR TITLE
Rename ticket summary component to changes summary

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+## TODOs
+
+- [ ] Improve commit generation, it's currently too simpler and often one line... Check a few commits and the changes to understand... Create a better list of changes.
+- [ ] Add support for using command agent when doing `@general /command args`.

--- a/kompass.jsonc
+++ b/kompass.jsonc
@@ -35,10 +35,10 @@
 
   "components": {
     "change-summary": { "enabled": true },
+    "changes-summary": { "enabled": true },
     "commit": { "enabled": true },
     "dev-flow": { "enabled": true },
     "summarize-changes": { "enabled": true },
-    "ticket-summary": { "enabled": true },
   },
 
   "skills": {

--- a/kompass.schema.json
+++ b/kompass.schema.json
@@ -158,6 +158,9 @@
         "change-summary": {
           "$ref": "#/$defs/componentConfig"
         },
+        "changes-summary": {
+          "$ref": "#/$defs/componentConfig"
+        },
         "commit": {
           "$ref": "#/$defs/componentConfig"
         },
@@ -167,14 +170,11 @@
         "summarize-changes": {
           "$ref": "#/$defs/componentConfig"
         },
-        "ticket-summary": {
-          "$ref": "#/$defs/componentConfig"
-        },
         "enabled": {
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["change-summary", "commit", "dev-flow", "summarize-changes", "ticket-summary"]
+            "enum": ["change-summary", "changes-summary", "commit", "dev-flow", "summarize-changes"]
           },
           "uniqueItems": true,
           "deprecated": true
@@ -182,7 +182,7 @@
         "paths": {
           "type": "object",
           "propertyNames": {
-            "enum": ["change-summary", "commit", "dev-flow", "summarize-changes", "ticket-summary"]
+            "enum": ["change-summary", "changes-summary", "commit", "dev-flow", "summarize-changes"]
           },
           "additionalProperties": {
             "type": "string"

--- a/packages/core/commands/pr/create.txt
+++ b/packages/core/commands/pr/create.txt
@@ -54,7 +54,7 @@ Store `$ARGUMENTS` as `<arguments>`, then analyze it to determine how to proceed
 ### Prepare Ticket Reference
 
 When `<ticket-mode>` is `auto`, create the ticket before creating the PR:
-{{ticket-summary}}
+{{changes-summary}}
 - Use `ticket_sync` with `refUrl` unset
 - Store the created issue reference or URL as `<ticket-url>`
 
@@ -76,11 +76,15 @@ Run `git push` and use its output as the source of truth.
 Use `pr_sync` to create the pull request:
 - Generate a concise title (max 70 chars) summarizing the change
 - Generate a short description that briefly describes the intent and scope
-- Generate a compact checklist with concrete validation items and any remaining follow-ups; mark completed items as appropriate
+- Generate a compact checklist that mirrors the same human-facing structure used for the ticket summary:
+  - group delivered work into 2-4 functional or outcome-focused sections
+  - use concise section names instead of generic labels like `Changes`
+  - end with one `Validation` section containing reviewer-facing confirmation steps
+  - do not use execution-status notes as checklist items
 - Render the PR body with this exact structure by setting `body` directly:
   - `## Ticket`, followed by `<ticket-url>` on the next line
   - `## Description`, followed by the short description
-  - `## Checklist`, followed by the checklist items
+  - `## Checklist`, followed by the checklist items and any subsection headings
 - Use `<base>` as the base branch if defined, otherwise leave it to use repo default
 - Do NOT restate the full diff
 - Keep it compact and directional

--- a/packages/core/commands/ticket/create.txt
+++ b/packages/core/commands/ticket/create.txt
@@ -21,7 +21,7 @@ Store `$ARGUMENTS` as `<arguments>`, then analyze it to determine how to proceed
 ### Create Ticket
 
 Use `ticket_sync` with `refUrl` unset to create the ticket:
-{{ticket-summary}}
+{{changes-summary}}
 - Store the created issue reference or URL as `<ticket-ref>`
 
 ## Additional Context

--- a/packages/core/components/changes-summary.txt
+++ b/packages/core/components/changes-summary.txt
@@ -1,0 +1,12 @@
+- Reuse the same change themes, rationale, and reviewer-facing validation goals from the current summary work
+- Generate a concise title (max 70 chars) that reflects the delivered outcome
+- Generate a `description` that briefly describes what was accomplished and why it matters
+- Generate checklists with:
+  - 2-4 functional sections named after user-facing areas or outcomes, not generic labels like `Changes`
+  - concise, outcome-focused items under each section that describe what changed for a human reader
+  - one final `Validation` section with reviewer-facing confirmation steps that start with `Verify that...`, `Confirm that...`, or `Check that...`
+- Keep section names and items concise, human-friendly, and function-oriented
+- Merge tiny themes together instead of creating a section per file or implementation detail
+- Do not restate the full diff
+- Do not use execution-status notes such as `Validation not run in this session` as checklist items
+- If `changes_load` reports uncommitted work, make that clear in the ticket wording

--- a/packages/core/components/ticket-summary.txt
+++ b/packages/core/components/ticket-summary.txt
@@ -1,9 +1,0 @@
-- Reuse the same change themes, rationale, and validation notes from the current summary work
-- Generate a concise title (max 70 chars) that reflects the delivered outcome
-- Generate a `description` that briefly describes what was accomplished and why it matters
-- Generate checklists with:
-  - `Changes` section listing the key changes made (concise, outcome-focused items)
-  - `Validation` section with concrete validation steps or confirmation that validation was performed
-- Keep items concise and outcome-focused
-- Do not restate the full diff
-- If `changes_load` reports uncommitted work, make that clear in the ticket wording

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -37,10 +37,10 @@ export const DEFAULT_AGENT_NAMES = ["planner", "reviewer"] as const;
 
 export const DEFAULT_COMPONENT_NAMES = [
   "change-summary",
+  "changes-summary",
   "commit",
   "dev-flow",
   "summarize-changes",
-  "ticket-summary",
 ] as const;
 
 export type ToolName = (typeof DEFAULT_TOOL_NAMES)[number];
@@ -120,10 +120,10 @@ export interface KompassConfig {
   };
   components?: {
     "change-summary"?: ComponentConfig;
+    "changes-summary"?: ComponentConfig;
     commit?: ComponentConfig;
     "dev-flow"?: ComponentConfig;
     "summarize-changes"?: ComponentConfig;
-    "ticket-summary"?: ComponentConfig;
     enabled?: string[];
     paths?: Record<string, string>;
   };
@@ -346,10 +346,10 @@ const defaultAgentPlanner: AgentDefinition = {
 
 const defaultComponentPaths: Record<string, string> = {
   "change-summary": "components/change-summary.txt",
+  "changes-summary": "components/changes-summary.txt",
   "commit": "components/commit.txt",
   "dev-flow": "components/dev-flow.txt",
   "summarize-changes": "components/summarize-changes.txt",
-  "ticket-summary": "components/ticket-summary.txt",
 };
 
 const defaultToolConfig: Record<ToolName, ToolConfig> = {

--- a/packages/opencode/.opencode/commands/pr/create.md
+++ b/packages/opencode/.opencode/commands/pr/create.md
@@ -76,14 +76,17 @@ Store `$ARGUMENTS` as `<arguments>`, then analyze it to determine how to proceed
 ### Prepare Ticket Reference
 
 When `<ticket-mode>` is `auto`, create the ticket before creating the PR:
-- Reuse the same change themes, rationale, and validation notes from the current summary work
+- Reuse the same change themes, rationale, and reviewer-facing validation goals from the current summary work
 - Generate a concise title (max 70 chars) that reflects the delivered outcome
 - Generate a `description` that briefly describes what was accomplished and why it matters
 - Generate checklists with:
-  - `Changes` section listing the key changes made (concise, outcome-focused items)
-  - `Validation` section with concrete validation steps or confirmation that validation was performed
-- Keep items concise and outcome-focused
+  - 2-4 functional sections named after user-facing areas or outcomes, not generic labels like `Changes`
+  - concise, outcome-focused items under each section that describe what changed for a human reader
+  - one final `Validation` section with reviewer-facing confirmation steps that start with `Verify that...`, `Confirm that...`, or `Check that...`
+- Keep section names and items concise, human-friendly, and function-oriented
+- Merge tiny themes together instead of creating a section per file or implementation detail
 - Do not restate the full diff
+- Do not use execution-status notes such as `Validation not run in this session` as checklist items
 - If `kompass_changes_load` reports uncommitted work, make that clear in the ticket wording
 - Use `kompass_ticket_sync` with `refUrl` unset
 - Store the created issue reference or URL as `<ticket-url>`
@@ -106,11 +109,15 @@ Run `git push` and use its output as the source of truth.
 Use `kompass_pr_sync` to create the pull request:
 - Generate a concise title (max 70 chars) summarizing the change
 - Generate a short description that briefly describes the intent and scope
-- Generate a compact checklist with concrete validation items and any remaining follow-ups; mark completed items as appropriate
+- Generate a compact checklist that mirrors the same human-facing structure used for the ticket summary:
+  - group delivered work into 2-4 functional or outcome-focused sections
+  - use concise section names instead of generic labels like `Changes`
+  - end with one `Validation` section containing reviewer-facing confirmation steps
+  - do not use execution-status notes as checklist items
 - Render the PR body with this exact structure by setting `body` directly:
   - `## Ticket`, followed by `<ticket-url>` on the next line
   - `## Description`, followed by the short description
-  - `## Checklist`, followed by the checklist items
+  - `## Checklist`, followed by the checklist items and any subsection headings
 - Use `<base>` as the base branch if defined, otherwise leave it to use repo default
 - Do NOT restate the full diff
 - Keep it compact and directional

--- a/packages/opencode/.opencode/commands/ticket/create.md
+++ b/packages/opencode/.opencode/commands/ticket/create.md
@@ -43,14 +43,17 @@ Store `$ARGUMENTS` as `<arguments>`, then analyze it to determine how to proceed
 ### Create Ticket
 
 Use `kompass_ticket_sync` with `refUrl` unset to create the ticket:
-- Reuse the same change themes, rationale, and validation notes from the current summary work
+- Reuse the same change themes, rationale, and reviewer-facing validation goals from the current summary work
 - Generate a concise title (max 70 chars) that reflects the delivered outcome
 - Generate a `description` that briefly describes what was accomplished and why it matters
 - Generate checklists with:
-  - `Changes` section listing the key changes made (concise, outcome-focused items)
-  - `Validation` section with concrete validation steps or confirmation that validation was performed
-- Keep items concise and outcome-focused
+  - 2-4 functional sections named after user-facing areas or outcomes, not generic labels like `Changes`
+  - concise, outcome-focused items under each section that describe what changed for a human reader
+  - one final `Validation` section with reviewer-facing confirmation steps that start with `Verify that...`, `Confirm that...`, or `Check that...`
+- Keep section names and items concise, human-friendly, and function-oriented
+- Merge tiny themes together instead of creating a section per file or implementation detail
 - Do not restate the full diff
+- Do not use execution-status notes such as `Validation not run in this session` as checklist items
 - If `kompass_changes_load` reports uncommitted work, make that clear in the ticket wording
 - Store the created issue reference or URL as `<ticket-ref>`
 


### PR DESCRIPTION
## Ticket
https://github.com/kompassdev/kompass/issues/17

## Description
Consolidates PR and ticket summary guidance under a shared `changes-summary` component, updates config and schema support for the rename, and carries forward a small TODO note for follow-up workflow improvements.

## Checklist
### Shared summaries
- [x] Replace the old `ticket-summary` partial with a shared `changes-summary` component for PR and ticket creation
- [x] Align the summary guidance around functional sections and reviewer-facing validation goals

### Config support
- [x] Add `changes-summary` to the workspace config, schema enums, and default component path mapping
- [x] Remove the old `ticket-summary` references from source configuration surfaces

### Command guidance
- [x] Update `pr/create` and `ticket/create` to use the renamed shared component
- [x] Regenerate the OpenCode command docs so published instructions match the source templates
- [x] Add a TODO note for follow-up improvements to commit generation and command-agent argument handling

### Validation
- [x] Verify that `changes-summary` is accepted anywhere component names or paths are configured
- [x] Confirm that PR and ticket creation docs now describe the same checklist structure and wording
- [x] Check that the old `ticket-summary` component is no longer referenced by source or generated command docs