### PR TITLE
Add branch command and tighten workflow guidance

### DIFF
--- a/packages/core/agents/planner.md
+++ b/packages/core/agents/planner.md
@@ -25,22 +25,22 @@ You are a planning specialist. Turn requests, tickets, and gathered context into
 ## Workflow
 
 1. Interpret the request.
-   - Identify the goal, constraints, context source, and expected output shape.
-   - If the request includes ticket context already, use it directly.
+    - Identify the goal, constraints, context source, and expected output shape.
+    - If the request includes ticket context already, use it directly.
 
 2. Gather only missing context.
-   - Use the provided context to resolve as much as possible before introducing questions.
-   - Only call out missing context when it creates real ambiguity around scope or outcome.
+    - Use the provided context to resolve as much as possible before introducing questions.
+    - Only call out missing context when it creates real ambiguity around scope or outcome.
 
 3. Shape the plan.
-   - Give the work a short, useful title.
-   - Write a short description that captures the intended outcome and scope.
-   - Produce concise checklist items centered on requirements and validation.
-   - Include assumptions or open questions only when they meaningfully affect execution.
+    - Give the work a short, useful title.
+    - Write a short description that captures the intended outcome and scope.
+    - Produce concise checklist items centered on requirements and validation.
+    - Include assumptions or open questions only when they meaningfully affect execution.
 
 4. Ask only when blocked.
-   - If the execution environment supports follow-up questions, ask only when a missing detail prevents a reliable plan.
-   - If follow-up questions are not available, proceed with the most reasonable interpretation and make assumptions or open questions explicit in the output when they matter.
+    - If the execution environment supports follow-up questions, ask only when a missing detail prevents a reliable plan.
+    - If follow-up questions are not available, proceed with the most reasonable interpretation and make assumptions or open questions explicit in the output when they matter.
 
 ## Checklist Rules
 

--- a/packages/core/agents/reviewer.md
+++ b/packages/core/agents/reviewer.md
@@ -11,36 +11,37 @@ Before reviewing, always check repository guidance:
 ## Review Workflow
 
 1. **Load Changes**: Use `changes_load` to get the changed-file set and structured diffs
-   - In CI or shallow clones, pass explicit base and head refs
-   - Scan the summary first to understand scope, file states, and risk clusters
-   - Never switch branches, create local review branches, or otherwise mutate `HEAD`; if a loader fails, prefer reporting the blocker over changing checkout state
+    - In CI or shallow clones, pass explicit base and head refs
+    - Scan the summary first to understand scope, file states, and risk clusters
+    - Never switch branches, create local review branches, or otherwise mutate `HEAD`; if a loader fails, prefer reporting the blocker over changing checkout state
 
 2. **Read Code**: Read every changed file individually before finalizing
-     - Read full current files for added/modified/renamed/copied/untracked files
-     - `changes_load` gives the changed-file set and diffs, but not full deleted-file contents; for deleted files, inspect previous contents from git
-     - Use diffs to prioritize, but don't treat hunks as sufficient context
-     - Prefer loading changed files directly in the current session so that file context remains available during analysis and write-up
-     - Use a helper agent only when the changed-file set is too large to review comfortably in one session after the changed paths are already known
-     - Stop expanding after reading changed files unless needed to confirm behavior
-     - Do not inspect unchanged implementations, callers, or repo-wide context unless a concrete suspected issue requires it
-     - Do not keep re-reading the same files once you already have enough evidence for the finding or no-finding decision
+    - Read full current files for added/modified/renamed/copied/untracked files
+    - `changes_load` gives the changed-file set and diffs, but not full deleted-file contents; for deleted files, inspect previous contents from git
+    - Use diffs to prioritize, but don't treat hunks as sufficient context
+    - Prefer loading changed files directly in the current session so that file context remains available during analysis and write-up
+    - Use a helper agent only when the changed-file set is too large to review comfortably in one session after the changed paths are already known
+    - Stop expanding after reading changed files unless needed to confirm behavior
+    - Do not inspect unchanged implementations, callers, or repo-wide context unless a concrete suspected issue requires it
+    - Do not keep re-reading the same files once you already have enough evidence for the finding or no-finding decision
+    - Before submitting, make sure you have identified all distinct material issues across the full changed-file set
 
 3. **Analyze**: Look for these material issues:
-   - Correctness bugs and logic regressions
-   - Broken edge cases and missing error handling  
-   - Data loss, auth, permission, privacy, or security problems
-   - API, schema, migration, and backward-compatibility hazards
-   - Concurrency, retry, caching, and state-management mistakes
-   - Accidental behavior changes vs intentional modifications
-   - Incorrect assumptions about null, empty, default, retry, timeout, ordering, permissions
-   - Caller and contract breakage (API shapes, return values, schemas, renamed exports)
-   - Partial updates (changed in one place but not dependent paths)
-   - Stale references from deleted/renamed files (docs, routes, imports, tests)
-   - Risky generated/lockfile churn hiding real changes
+    - Correctness bugs and logic regressions
+    - Broken edge cases and missing error handling
+    - Data loss, auth, permission, privacy, or security problems
+    - API, schema, migration, and backward-compatibility hazards
+    - Concurrency, retry, caching, and state-management mistakes
+    - Accidental behavior changes vs intentional modifications
+    - Incorrect assumptions about null, empty, default, retry, timeout, ordering, permissions
+    - Caller and contract breakage (API shapes, return values, schemas, renamed exports)
+    - Partial updates (changed in one place but not dependent paths)
+    - Stale references from deleted/renamed files (docs, routes, imports, tests)
+    - Risky generated/lockfile churn hiding real changes
 
-4. **Skip Noise**: 
-   - Skip generated, lockfile, or bulk-format churn unless meaningful
-   - Don't read every downstream caller—only root cause files
+4. **Skip Noise**:
+    - Skip generated, lockfile, or bulk-format churn unless meaningful
+    - Don't read every downstream caller - only root cause files
 
 ## Finding Threshold
 
@@ -64,7 +65,7 @@ When generating reviews, provide:
 1. **Overall Grade**: Format as stars `★★☆☆☆` (1-5 stars)
 2. **Body Note**: Optional; include only when there is review feedback that does not fit an inline comment
 3. **Findings List**: Ordered by impact (critical → high → medium → low)
-   - Only high-confidence, actionable findings
+    - Only high-confidence, actionable findings
     - Be specific about failure modes and why they matter
     - Suggest the smallest practical fix
     - Explicitly state "No material issues found" when applicable
@@ -74,4 +75,4 @@ If there are no non-inline notes, omit the body note entirely.
 If there are no inline findings and no body note, the overall grade must be `★★★★★`.
 Any grade below `★★★★★` must include at least one inline finding or a non-inline body note with actionable feedback.
 
-Prefer fewer, stronger findings over many speculative ones.
+Prefer fewer, stronger findings over many speculative ones, but do not under-report distinct material issues that belong in the same review.

--- a/packages/core/commands/branch.md
+++ b/packages/core/commands/branch.md
@@ -1,0 +1,54 @@
+## Goal
+
+Create and switch to a categorized branch whose name summarizes the current uncommitted work.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` provides wording that should influence the branch name, store it as `<branch-context>`
+- Otherwise, leave `<branch-context>` undefined
+
+### Load Changes
+
+{{change-summary rules="- pass `uncommitted: true` to get uncommitted changes only"}}
+- Store the loaded change result as `<changes>`
+- Store the current branch as `<current-branch>` when it is available
+
+### Check Blockers
+
+- If `<changes>` contains no files, STOP and report that there is nothing to branch from
+
+### Create Branch
+
+- Choose a branch category from the summarized change themes and `<branch-context>`
+- Prefer conventional categories such as `feature`, `fix`, `refactor`, `docs`, `test`, or `chore`
+- Store the chosen category as `<branch-category>`
+- Generate a concise kebab-case slug from the summarized change themes and `<branch-context>` when available, then store it as `<branch-slug>`
+- Create and checkout `<branch-category>/<branch-slug>` with `git checkout -b`
+- If that name already exists, retry once with a short numeric suffix
+- Store the checked-out branch as `<new-branch>`
+
+## Additional Context
+
+Use `<branch-context>` to steer the branch category and slug while keeping the final name short, descriptive, and aligned with the change type.
+
+## Output
+
+If there is nothing to branch from, display:
+```
+Nothing to branch from
+```
+
+When the branch is created, display:
+```
+Created branch: <new-branch>
+
+From: <current-branch>
+```

--- a/packages/core/commands/index.ts
+++ b/packages/core/commands/index.ts
@@ -10,6 +10,11 @@ interface CommandDefinition {
 }
 
 export const commandDefinitions: Record<string, CommandDefinition> = {
+  branch: {
+    description: "Create a feature branch from current changes",
+    agent: "build",
+    templatePath: "commands/branch.md",
+  },
   commit: {
     description: "Commit current changes with a message",
     agent: "build",

--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -86,10 +86,11 @@ Use `<additional-context>` when prioritizing which review feedback to address fi
 
 ## Output
 
-When fixes are complete, display:
+When fixes are complete, display exactly this final completion summary and stop. Do not continue with extra analysis, planning, or follow-up tasks unless the workflow is blocked or the user asked for more:
 ```
-Addressed feedback on PR #<pr-context.pr.number>
+PR fix complete for #<pr-context.pr.number>
 
+- Status: complete, no additional steps needed
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>
 - Tests passing: <tests-passing>

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -17,6 +17,7 @@ export const DEFAULT_TOOL_NAMES = [
 ] as const;
 
 export const DEFAULT_COMMAND_NAMES = [
+  "branch",
   "commit",
   "commit-and-push",
   "dev",
@@ -90,6 +91,7 @@ export interface SkillIdentity {
 
 export interface KompassConfig {
   commands?: {
+    branch?: CommandConfig;
     commit?: CommandConfig;
     "commit-and-push"?: CommandConfig;
     dev?: CommandConfig;

--- a/packages/opencode/.opencode/agents/planner.md
+++ b/packages/opencode/.opencode/agents/planner.md
@@ -32,22 +32,22 @@ You are a planning specialist. Turn requests, tickets, and gathered context into
 ## Workflow
 
 1. Interpret the request.
-   - Identify the goal, constraints, context source, and expected output shape.
-   - If the request includes ticket context already, use it directly.
+    - Identify the goal, constraints, context source, and expected output shape.
+    - If the request includes ticket context already, use it directly.
 
 2. Gather only missing context.
-   - Use the provided context to resolve as much as possible before introducing questions.
-   - Only call out missing context when it creates real ambiguity around scope or outcome.
+    - Use the provided context to resolve as much as possible before introducing questions.
+    - Only call out missing context when it creates real ambiguity around scope or outcome.
 
 3. Shape the plan.
-   - Give the work a short, useful title.
-   - Write a short description that captures the intended outcome and scope.
-   - Produce concise checklist items centered on requirements and validation.
-   - Include assumptions or open questions only when they meaningfully affect execution.
+    - Give the work a short, useful title.
+    - Write a short description that captures the intended outcome and scope.
+    - Produce concise checklist items centered on requirements and validation.
+    - Include assumptions or open questions only when they meaningfully affect execution.
 
 4. Ask only when blocked.
-   - If the execution environment supports follow-up questions, ask only when a missing detail prevents a reliable plan.
-   - If follow-up questions are not available, proceed with the most reasonable interpretation and make assumptions or open questions explicit in the output when they matter.
+    - If the execution environment supports follow-up questions, ask only when a missing detail prevents a reliable plan.
+    - If follow-up questions are not available, proceed with the most reasonable interpretation and make assumptions or open questions explicit in the output when they matter.
 
 ## Checklist Rules
 

--- a/packages/opencode/.opencode/agents/reviewer.md
+++ b/packages/opencode/.opencode/agents/reviewer.md
@@ -18,36 +18,37 @@ Before reviewing, always check repository guidance:
 ## Review Workflow
 
 1. **Load Changes**: Use `kompass_changes_load` to get the changed-file set and structured diffs
-   - In CI or shallow clones, pass explicit base and head refs
-   - Scan the summary first to understand scope, file states, and risk clusters
-   - Never switch branches, create local review branches, or otherwise mutate `HEAD`; if a loader fails, prefer reporting the blocker over changing checkout state
+    - In CI or shallow clones, pass explicit base and head refs
+    - Scan the summary first to understand scope, file states, and risk clusters
+    - Never switch branches, create local review branches, or otherwise mutate `HEAD`; if a loader fails, prefer reporting the blocker over changing checkout state
 
 2. **Read Code**: Read every changed file individually before finalizing
-     - Read full current files for added/modified/renamed/copied/untracked files
-     - `kompass_changes_load` gives the changed-file set and diffs, but not full deleted-file contents; for deleted files, inspect previous contents from git
-     - Use diffs to prioritize, but don't treat hunks as sufficient context
-     - Prefer loading changed files directly in the current session so that file context remains available during analysis and write-up
-     - Use a helper agent only when the changed-file set is too large to review comfortably in one session after the changed paths are already known
-     - Stop expanding after reading changed files unless needed to confirm behavior
-     - Do not inspect unchanged implementations, callers, or repo-wide context unless a concrete suspected issue requires it
-     - Do not keep re-reading the same files once you already have enough evidence for the finding or no-finding decision
+    - Read full current files for added/modified/renamed/copied/untracked files
+    - `kompass_changes_load` gives the changed-file set and diffs, but not full deleted-file contents; for deleted files, inspect previous contents from git
+    - Use diffs to prioritize, but don't treat hunks as sufficient context
+    - Prefer loading changed files directly in the current session so that file context remains available during analysis and write-up
+    - Use a helper agent only when the changed-file set is too large to review comfortably in one session after the changed paths are already known
+    - Stop expanding after reading changed files unless needed to confirm behavior
+    - Do not inspect unchanged implementations, callers, or repo-wide context unless a concrete suspected issue requires it
+    - Do not keep re-reading the same files once you already have enough evidence for the finding or no-finding decision
+    - Before submitting, make sure you have identified all distinct material issues across the full changed-file set
 
 3. **Analyze**: Look for these material issues:
-   - Correctness bugs and logic regressions
-   - Broken edge cases and missing error handling  
-   - Data loss, auth, permission, privacy, or security problems
-   - API, schema, migration, and backward-compatibility hazards
-   - Concurrency, retry, caching, and state-management mistakes
-   - Accidental behavior changes vs intentional modifications
-   - Incorrect assumptions about null, empty, default, retry, timeout, ordering, permissions
-   - Caller and contract breakage (API shapes, return values, schemas, renamed exports)
-   - Partial updates (changed in one place but not dependent paths)
-   - Stale references from deleted/renamed files (docs, routes, imports, tests)
-   - Risky generated/lockfile churn hiding real changes
+    - Correctness bugs and logic regressions
+    - Broken edge cases and missing error handling
+    - Data loss, auth, permission, privacy, or security problems
+    - API, schema, migration, and backward-compatibility hazards
+    - Concurrency, retry, caching, and state-management mistakes
+    - Accidental behavior changes vs intentional modifications
+    - Incorrect assumptions about null, empty, default, retry, timeout, ordering, permissions
+    - Caller and contract breakage (API shapes, return values, schemas, renamed exports)
+    - Partial updates (changed in one place but not dependent paths)
+    - Stale references from deleted/renamed files (docs, routes, imports, tests)
+    - Risky generated/lockfile churn hiding real changes
 
-4. **Skip Noise**: 
-   - Skip generated, lockfile, or bulk-format churn unless meaningful
-   - Don't read every downstream caller—only root cause files
+4. **Skip Noise**:
+    - Skip generated, lockfile, or bulk-format churn unless meaningful
+    - Don't read every downstream caller - only root cause files
 
 ## Finding Threshold
 
@@ -71,7 +72,7 @@ When generating reviews, provide:
 1. **Overall Grade**: Format as stars `★★☆☆☆` (1-5 stars)
 2. **Body Note**: Optional; include only when there is review feedback that does not fit an inline comment
 3. **Findings List**: Ordered by impact (critical → high → medium → low)
-   - Only high-confidence, actionable findings
+    - Only high-confidence, actionable findings
     - Be specific about failure modes and why they matter
     - Suggest the smallest practical fix
     - Explicitly state "No material issues found" when applicable
@@ -81,4 +82,4 @@ If there are no non-inline notes, omit the body note entirely.
 If there are no inline findings and no body note, the overall grade must be `★★★★★`.
 Any grade below `★★★★★` must include at least one inline finding or a non-inline body note with actionable feedback.
 
-Prefer fewer, stronger findings over many speculative ones.
+Prefer fewer, stronger findings over many speculative ones, but do not under-report distinct material issues that belong in the same review.

--- a/packages/opencode/.opencode/commands/branch.md
+++ b/packages/opencode/.opencode/commands/branch.md
@@ -1,0 +1,72 @@
+---
+description: Create a feature branch from current changes
+agent: build
+---
+
+## Goal
+
+Create and switch to a categorized branch whose name summarizes the current uncommitted work.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` provides wording that should influence the branch name, store it as `<branch-context>`
+- Otherwise, leave `<branch-context>` undefined
+
+### Load Changes
+
+#### Step 1: Load Changes
+- call `kompass_changes_load`
+- pass `uncommitted: true` to get uncommitted changes only
+- Store the returned result as `<changes>`
+- Use `<changes>` as the source of truth; no additional git analysis commands are needed
+
+#### Step 2: Analyze Files
+- Review the paths, statuses, and diffs from `<changes>`
+- Identify the nature of changes (added, modified, deleted)
+- Note lines added/removed per file
+
+#### Step 3: Group and Summarize
+- Group related changes into logical themes
+- Summarize the "what" and "why" (not the "how")
+- Store the loaded change result as `<changes>`
+- Store the current branch as `<current-branch>` when it is available
+
+### Check Blockers
+
+- If `<changes>` contains no files, STOP and report that there is nothing to branch from
+
+### Create Branch
+
+- Choose a branch category from the summarized change themes and `<branch-context>`
+- Prefer conventional categories such as `feature`, `fix`, `refactor`, `docs`, `test`, or `chore`
+- Store the chosen category as `<branch-category>`
+- Generate a concise kebab-case slug from the summarized change themes and `<branch-context>` when available, then store it as `<branch-slug>`
+- Create and checkout `<branch-category>/<branch-slug>` with `git checkout -b`
+- If that name already exists, retry once with a short numeric suffix
+- Store the checked-out branch as `<new-branch>`
+
+## Additional Context
+
+Use `<branch-context>` to steer the branch category and slug while keeping the final name short, descriptive, and aligned with the change type.
+
+## Output
+
+If there is nothing to branch from, display:
+```
+Nothing to branch from
+```
+
+When the branch is created, display:
+```
+Created branch: <new-branch>
+
+From: <current-branch>
+```

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -91,10 +91,11 @@ Use `<additional-context>` when prioritizing which review feedback to address fi
 
 ## Output
 
-When fixes are complete, display:
+When fixes are complete, display exactly this final completion summary and stop. Do not continue with extra analysis, planning, or follow-up tasks unless the workflow is blocked or the user asked for more:
 ```
-Addressed feedback on PR #<pr-context.pr.number>
+PR fix complete for #<pr-context.pr.number>
 
+- Status: complete, no additional steps needed
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>
 - Tests passing: <tests-passing>

--- a/packages/opencode/.opencode/kompass.jsonc
+++ b/packages/opencode/.opencode/kompass.jsonc
@@ -1,5 +1,8 @@
 {
   "commands": {
+    "branch": {
+      "enabled": true
+    },
     "commit": {
       "enabled": true
     },

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -27,6 +27,7 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       const expectedCommands = [
+        "branch",
         "reload",
         "pr/create",
         "pr/review",
@@ -51,6 +52,7 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       assert.equal(cfg.command!["pr/review"]?.agent, "reviewer");
+      assert.equal(cfg.command!["branch"]?.agent, "build");
       assert.equal(cfg.command!["reload"]?.agent, "build");
       assert.equal(cfg.command!["pr/create"]?.agent, "build");
       assert.equal(cfg.command!["ticket/create"]?.agent, "build");
@@ -61,6 +63,7 @@ describe("applyCommandsConfig", () => {
       assert.ok(cfg.command!["pr/review"]?.description);
       assert.ok(cfg.command!["reload"]?.template);
       assert.ok(cfg.command!["dev"]?.template);
+      assert.ok(cfg.command!["branch"]?.template);
     });
   });
 


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Adds a dedicated branch command to the default command set and aligns command guidance so branch creation, PR fixes, and review expectations stay consistent across core and generated OpenCode outputs.

## Checklist
### Branch workflow
- [x] Add a `branch` command definition and config support so it is available by default
- [x] Cover branch command registration in the OpenCode command config tests

### Guidance alignment
- [x] Add the branch command authoring workflow template
- [x] Tighten reviewer and PR-fix guidance in core and generated command outputs

### Validation
- [x] Verify that default command registration includes `branch`
- [x] Confirm that generated OpenCode command templates stay aligned with the source command docs