### PR TITLE
Add Eta component templating to shared commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,19 @@ Before delegating, write the exact `<task ...>...</task>` block, say what result
 ## Component Authoring
 
 - Store reusable command fragments in `packages/core/components/`
+- Treat files in `packages/core/components/` as Eta partials and include them from commands with `<%~ include("@partial-name") %>`
+- Pass partial-specific locals with the second `include` argument, for example `<%~ include("@change-summary", { rules: "..." }) %>`
 - Create a component only when the same structure or wording is needed in multiple commands; if a section is only used once, keep it inline in the command file
 - Keep components focused on repeatable building blocks, such as shared workflow steps, analysis patterns, or output scaffolding
 - Components should complement command docs, not hide the command's main intent; commands should still read clearly when expanded
 - When a reusable pattern emerges from existing inline text, extract it into a component rather than duplicating and drifting over time
+
+## Template Authoring
+
+- Command and component files render through Eta
+- Use Eta syntax for conditionals and includes; do not introduce custom placeholder syntaxes
+- Store command-specific render inputs directly on `commands.<name>` in config, for example `commands.pr/review.approve`
+- Custom command templates are rendered through the same Eta pipeline as bundled templates
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Create, update, or review a GitHub pull request with structured checklists.
 - `body` (optional): raw PR body override
 - `description` (optional): short PR description rendered above checklist sections
 - `base` (optional): base branch to merge into
+- `head` (optional): head branch to use when creating a PR
 - `checklists` (optional): structured checklist sections (e.g., Testing, Summary)
 - `draft` (optional): create as draft PR
 - `refUrl` (optional): PR URL to update instead of creating new

--- a/bun.lock
+++ b/bun.lock
@@ -12,10 +12,13 @@
     "packages/core": {
       "name": "@kompassdev/core",
       "version": "0.0.3",
+      "dependencies": {
+        "eta": "^4.5.1",
+      },
     },
     "packages/opencode": {
       "name": "@kompassdev/opencode",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.2.25",
         "@opencode-ai/sdk": "^1.2.25",
@@ -36,6 +39,8 @@
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.25", "", {}, "sha512-ikuGWob48OM7LTgfXFqGOZKVOqh50FEjvtIBhXGhGowJhifmjZ+xuq/ypP8nPjTwUX73pbu1C3X9ZBWVkCN9mA=="],
 
     "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "eta": ["eta@4.5.1", "", {}, "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/packages/core/commands/branch.md
+++ b/packages/core/commands/branch.md
@@ -17,7 +17,7 @@ $ARGUMENTS
 
 ### Load Changes
 
-{{change-summary rules="- pass `uncommitted: true` to get uncommitted changes only"}}
+<%~ include("@change-summary", { rules: "- pass `uncommitted: true` to get uncommitted changes only" }) %>
 - Store the loaded change result as `<changes>`
 - Store the current branch as `<current-branch>` when it is available
 

--- a/packages/core/commands/commit-and-push.md
+++ b/packages/core/commands/commit-and-push.md
@@ -17,7 +17,7 @@ $ARGUMENTS
 
 ### Load Changes
 
-{{change-summary rules="- pass `uncommitted: true` to get uncommitted changes only"}}
+<%~ include("@change-summary", { rules: "- pass `uncommitted: true` to get uncommitted changes only" }) %>
 - Store the loaded change result as `<changes>`
 
 ### Check Blockers
@@ -26,7 +26,7 @@ $ARGUMENTS
 
 ### Create Commit
 
-{{commit}}
+<%~ include("@commit") %>
 - Store the created commit hash as `<hash>`
 
 ### Push to Remote

--- a/packages/core/commands/commit.md
+++ b/packages/core/commands/commit.md
@@ -17,7 +17,7 @@ $ARGUMENTS
 
 ### Load Changes
 
-{{change-summary rules="- pass `uncommitted: true` to get uncommitted changes only"}}
+<%~ include("@change-summary", { rules: "- pass `uncommitted: true` to get uncommitted changes only" }) %>
 - Store the loaded change result as `<changes>`
 
 ### Check Blockers
@@ -26,7 +26,7 @@ $ARGUMENTS
 
 ### Create Commit
 
-{{commit}}
+<%~ include("@commit") %>
 - Store the created commit hash as `<hash>`
 
 ## Additional Context

--- a/packages/core/commands/dev.md
+++ b/packages/core/commands/dev.md
@@ -28,7 +28,7 @@ $ARGUMENTS
 - Summarize the goal, constraints, and acceptance criteria from `<request-context>` before making changes
 - Store that summary as `<request-summary>`
 
-{{dev-flow}}
+<%~ include("@dev-flow") %>
 
 ### Validate Changes
 

--- a/packages/core/commands/index.ts
+++ b/packages/core/commands/index.ts
@@ -1,4 +1,4 @@
-import { embedComponents } from "../lib/components.ts";
+import { renderTemplate } from "../lib/components.ts";
 import { loadKompassConfig, mergeWithDefaults } from "../lib/config.ts";
 import { loadProjectText } from "../lib/text.ts";
 
@@ -7,6 +7,7 @@ interface CommandDefinition {
   agent: string;
   templatePath: string;
   subtask?: boolean;
+  config?: Record<string, unknown>;
 }
 
 export const commandDefinitions: Record<string, CommandDefinition> = {
@@ -56,6 +57,9 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
     description: "Review the current PR and publish review feedback",
     agent: "reviewer",
     templatePath: "commands/pr/review.md",
+    config: {
+      approve: false,
+    },
   },
   review: {
     description: "Review branch changes without publishing comments",
@@ -136,13 +140,15 @@ export async function resolveCommands(
       config.commands.templates[name] || definition.templatePath;
 
     let template: string;
+    const commandConfig = {
+      enabled: true,
+      ...(definition.config ?? {}),
+      ...(config.commands.entries[name] ?? {}),
+    };
+
     try {
       const rawTemplate = await loadProjectText(templatePath);
-      // Only embed components if using default template
-      // Custom templates bypass component expansion (allows users full control)
-      template = config.commands.templates[name]
-        ? rawTemplate
-        : embedComponents(rawTemplate, components);
+      template = renderTemplate(rawTemplate, components, commandConfig);
     } catch {
       // Template file doesn't exist, skip
       continue;
@@ -153,6 +159,7 @@ export async function resolveCommands(
       agent: definition.agent,
       subtask: definition.subtask ?? !isCi,
       template,
+      ...(Object.keys(commandConfig).length > 0 ? { config: commandConfig } : {}),
     };
   }
 

--- a/packages/core/commands/pr/create.md
+++ b/packages/core/commands/pr/create.md
@@ -21,9 +21,7 @@ $ARGUMENTS
 
 ### Load & Analyze Changes
 
-{{change-summary rules="- If `<base>` is defined: call `changes_load` with the `base` parameter set to `<base>`
-- Otherwise: call `changes_load` with no parameters
-- Never pass `uncommitted: true` in this command"}}
+<%~ include("@change-summary", { rules: "- If `<base>` is defined: call `changes_load` with the `base` parameter set to `<base>`\n- Otherwise: call `changes_load` with no parameters\n- Never pass `uncommitted: true` in this command" }) %>
 
 - Store the loaded change result as `<changes>`
 - Store the current branch from `<changes>` as `<current-branch>` when it is available
@@ -44,7 +42,7 @@ $ARGUMENTS
   - Do NOT proceed further
 - If `<changes>` contains no files and no commits, STOP and report that there is nothing to include in a PR
 
-{{summarize-changes}}
+<%~ include("@summarize-changes") %>
 
 ### Resolve Ticket
 
@@ -73,7 +71,7 @@ $ARGUMENTS
 ### Prepare Ticket Reference
 
 When `<ticket-mode>` is `auto`, create the ticket before creating the PR:
-{{changes-summary}}
+<%~ include("@changes-summary") %>
 - Use `ticket_sync` with `refUrl` unset
 - Store the created issue reference or URL as `<ticket-url>`
 
@@ -97,6 +95,7 @@ Run `git push` and use its output as the source of truth.
 Use `pr_sync` to create the pull request:
 - Generate a concise title (max 70 chars) summarizing the change and store it as `<pr-title>`
 - Generate a short description that briefly describes the intent and scope
+- Pass `<current-branch>` as `head` when it is available so PR creation does not depend on local upstream inference
 - Generate a compact checklist that mirrors the same human-facing structure used for the ticket summary:
   - group delivered work into 2-4 functional or outcome-focused sections
   - use concise section names instead of generic labels like `Changes`

--- a/packages/core/commands/pr/review.md
+++ b/packages/core/commands/pr/review.md
@@ -51,7 +51,11 @@ Before publishing, derive: `<has-inline-comments>`, `<has-body-note>`, `<publish
 **Grading and Publishing Rules:**
 1. Assign a grade based on code quality (1-5 stars)
 2. If grade is below `★★★★★` without supporting feedback (inline comments or body note), you MUST add feedback - never publish a low grade without explaining why
+<% if (it.approve !== false) { %>
 3. **NEVER post a review with `★★★★★`** - if the final grade is 5 stars, approve the PR instead
+<% } else { %>
+3. If the final grade is `★★★★★`, publish it as review feedback instead of approving the PR
+<% } %>
 4. If there are issues (grade < 5 stars), create inline comments on specific lines
 
 **Inline comment format:**
@@ -65,9 +69,17 @@ For multi-line: add `startLine`. For deleted lines: use `side: "LEFT"`.
 
 ### Publish Review
 
+<% if (it.approve !== false) { %>
 **If `<publish-grade>` is `★★★★★`:**
 - Already approved → skip
 - Otherwise → `pr_sync` with `refUrl: <pr-context.pr.url>` and only `review.approve: true`
+<% } else { %>
+**If `<publish-grade>` is `★★★★★`:**
+- Pass `refUrl: <pr-context.pr.url>`
+- `review.body`: `★★★★★` plus any optional positive summary notes
+- Do not pass `review.approve`
+- Do not pass any other fields
+<% } %>
 
 **If `<publish-grade>` < `★★★★★`:**
 - Pass `refUrl: <pr-context.pr.url>`
@@ -83,6 +95,7 @@ Use `<ticket-context>` and `<additional-context>` to judge whether the PR meets 
 
 ## Output
 
+<% if (it.approve !== false) { %>
 When approved:
 ```
 PR approved for #<pr-context.pr.number>
@@ -96,8 +109,9 @@ Approval skipped for PR #<pr-context.pr.number>
 
 - Reason: current head already approved
 ```
+<% } %>
 
-When review published (grade < 5 stars with feedback):
+When review published:
 ```
 Review submitted for PR #<pr-context.pr.number>
 

--- a/packages/core/commands/ticket/create.md
+++ b/packages/core/commands/ticket/create.md
@@ -18,8 +18,7 @@ $ARGUMENTS
 
 ### Load & Analyze Changes
 
-{{change-summary rules="- If `<base>` is defined: call `changes_load` with the `base` parameter set to `<base>`
-- Otherwise: call `changes_load` with no parameters"}}
+<%~ include("@change-summary", { rules: "- If `<base>` is defined: call `changes_load` with the `base` parameter set to `<base>`\n- Otherwise: call `changes_load` with no parameters" }) %>
 
 - Store the loaded change result as `<changes>`
 
@@ -27,12 +26,12 @@ $ARGUMENTS
 
 - If `<changes>` contains no files, STOP and report that there is no work to summarize in a ticket
 
-{{summarize-changes}}
+<%~ include("@summarize-changes") %>
 
 ### Create Ticket
 
 Use `ticket_sync` with `refUrl` unset to create the ticket:
-{{changes-summary}}
+<%~ include("@changes-summary") %>
 - Store the generated title as `<ticket-title>`
 - Store the created issue URL as `<ticket-url>`
 

--- a/packages/core/commands/ticket/dev.md
+++ b/packages/core/commands/ticket/dev.md
@@ -24,7 +24,7 @@ $ARGUMENTS
 - Store a concise ticket summary as `<ticket-summary>`
 - If `<ticket-context>` cannot be loaded, STOP and report that the ticket source is missing or invalid
 
-{{dev-flow}}
+<%~ include("@dev-flow") %>
 
 ### Validate Changes
 

--- a/packages/core/components/change-summary.md
+++ b/packages/core/components/change-summary.md
@@ -1,6 +1,6 @@
 #### Step 1: Load Changes
 - call `changes_load`
-{{param:rules}}
+<%= it.rules ?? "" %>
 - Store the returned result as `<changes>`
 - Use `<changes>` as the source of truth; no additional git analysis commands are needed
 

--- a/packages/core/lib/components.ts
+++ b/packages/core/lib/components.ts
@@ -1,30 +1,17 @@
-export function parseComponentParams(paramString: string): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (!paramString) return params;
+import { Eta } from "eta";
 
-  // Match key="value" or key='value' patterns (supports multi-line with dotAll)
-  const regex = /(\w+)=["']([\s\S]*?)["']/g;
-  let match;
-  while ((match = regex.exec(paramString)) !== null) {
-    params[match[1]] = match[2];
-  }
-  return params;
-}
+type TemplateData = Record<string, unknown>;
 
-export function embedComponents(
+export function renderTemplate(
   template: string,
   components: Record<string, string>,
+  data: TemplateData = {},
 ): string {
-  // Match {{component-name}} or {{component-name param1="value1" param2="value2"}}
-  return template.replace(/\{\{([\w-]+)(\s+[^}]+)?\}\}/g, (match, name, paramsStr) => {
-    const component = components[name];
-    if (!component) return match;
+  const eta = new Eta({ autoEscape: false, autoTrim: false });
 
-    const params = parseComponentParams(paramsStr || "");
+  for (const [name, content] of Object.entries(components)) {
+    eta.loadTemplate(`@${name}`, content);
+  }
 
-    // Replace {{param:key}} placeholders in component content
-    return component.replace(/\{\{param:(\w+)\}\}/g, (paramMatch, paramName) => {
-      return params[paramName] !== undefined ? params[paramName] : paramMatch;
-    });
-  });
+  return eta.renderString(template, data) ?? "";
 }

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -61,6 +61,7 @@ export interface ToggleConfig {
 
 export interface CommandConfig extends ToggleConfig {
   template?: string;
+  [key: string]: unknown;
 }
 
 export interface AgentConfig extends ToggleConfig, Partial<AgentDefinition> {}
@@ -149,6 +150,7 @@ export interface MergedKompassConfig {
   commands: {
     enabled: string[];
     templates: Record<string, string>;
+    entries: Record<string, CommandConfig>;
   };
   agents: {
     enabled: string[];
@@ -409,6 +411,13 @@ function getCommandTemplate(
   return entry?.template ?? config?.commands?.templates?.[name];
 }
 
+function getCommandEntry(
+  config: KompassConfig | null,
+  name: CommandName,
+): CommandConfig | undefined {
+  return getToggleEntry<CommandConfig>(config?.commands, name);
+}
+
 function getComponentPath(
   config: KompassConfig | null,
   name: ComponentName,
@@ -516,6 +525,12 @@ export function mergeWithDefaults(
         DEFAULT_COMMAND_NAMES.flatMap((name) => {
           const template = getCommandTemplate(config, name);
           return template ? [[name, template]] : [];
+        }),
+      ),
+      entries: Object.fromEntries(
+        DEFAULT_COMMAND_NAMES.flatMap((name) => {
+          const entry = getCommandEntry(config, name);
+          return entry ? [[name, entry]] : [];
         }),
       ),
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,5 +29,8 @@
     "toolkit",
     "agents"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "eta": "^4.5.1"
+  }
 }

--- a/packages/core/test/changes-load.e2e.test.ts
+++ b/packages/core/test/changes-load.e2e.test.ts
@@ -220,6 +220,29 @@ describe("changes_load e2e", () => {
     assert.match(result.commits[0].subject, /feature commit/);
   });
 
+  test("branch comparison refreshes stale base branch before diffing", async () => {
+    const remote = await createRepo();
+    await commitFile(remote, "base.txt", "base\n", "init");
+    await git(remote, ["checkout", "-b", "feature"]);
+    await commitFile(remote, "feature.txt", "feature\n", "feature commit");
+    await git(remote, ["checkout", "main"]);
+
+    const bare = await cloneBare(remote);
+    await git(remote, ["remote", "add", "origin", `file://${bare}`]);
+    const clone = await cloneShallowBranch(bare, "feature");
+    await git(clone, ["fetch", "--depth=1", "origin", "main:refs/remotes/origin/main"]);
+
+    await git(remote, ["merge", "--ff-only", "feature"]);
+    await git(remote, ["push", "origin", "main"]);
+
+    const result = await runChangesLoad(clone, { base: "main", head: "feature" });
+
+    assert.equal(result.comparison, "origin/main...origin/feature");
+    assert.equal(result.branch, "feature");
+    assert.deepEqual(result.files, []);
+    assert.equal(result.commits, undefined);
+  });
+
 });
 
 async function createRepo() {

--- a/packages/core/test/commands.test.ts
+++ b/packages/core/test/commands.test.ts
@@ -1,0 +1,12 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveCommands } from "../commands/index.ts";
+
+describe("resolveCommands", () => {
+  test("includes default config for pr/review", async () => {
+    const commands = await resolveCommands(process.cwd());
+
+    assert.deepEqual(commands["pr/review"]?.config, { enabled: true, approve: false });
+  });
+});

--- a/packages/core/test/components.test.ts
+++ b/packages/core/test/components.test.ts
@@ -1,0 +1,27 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { renderTemplate } from "../lib/components.ts";
+
+describe("renderTemplate", () => {
+  test("renders Eta partials from registered components", () => {
+    const output = renderTemplate(
+      "Before\n<%~ include(\"@snippet\", { message: \"Hello\" }) %>\nAfter",
+      {
+        snippet: "Message: <%= it.message %>",
+      },
+    );
+
+    assert.equal(output, "Before\nMessage: Hello\nAfter");
+  });
+
+  test("supports Eta conditionals with template data", () => {
+    const output = renderTemplate(
+      "<% if (it.approve === false) { %>stars<% } else { %>approve<% } %>",
+      {},
+      { approve: false },
+    );
+
+    assert.equal(output, "stars");
+  });
+});

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -46,6 +46,7 @@ describe("object-based config", () => {
       commands: {
         dev: { enabled: false },
         review: { enabled: true, template: "commands/custom-review.md" },
+        "pr/review": { approve: false },
       },
       agents: {
         navigator: { permission: { task: "deny", todowrite: "deny" } },
@@ -60,6 +61,7 @@ describe("object-based config", () => {
     assert.equal(config.commands.enabled.includes("dev"), false);
     assert.equal(config.commands.enabled.includes("review"), true);
     assert.equal(config.commands.templates.review, "commands/custom-review.md");
+    assert.deepEqual(config.commands.entries["pr/review"], { approve: false });
     assert.deepEqual(config.agents.navigator.permission, {
       task: "deny",
       todowrite: "deny",

--- a/packages/core/test/pr-sync.test.ts
+++ b/packages/core/test/pr-sync.test.ts
@@ -6,6 +6,52 @@ import type { Shell, ShellPromise } from "../tools/shared.ts";
 import { createPrSyncTool } from "../tools/pr-sync.ts";
 
 describe("pr_sync", () => {
+  test("creates a PR with explicit head branch", async () => {
+    const executedCommands: string[] = [];
+    const shell = createMockShell(executedCommands, [
+      {
+        contains: "gh pr create",
+        stdout: "https://github.com/acme/repo/pull/10\n",
+      },
+    ]);
+
+    const tool = createPrSyncTool(shell);
+    const output = await tool.execute({
+      title: "Improve PR creation reliability",
+      body: "Uses explicit head branch when creating PRs.",
+      base: "main",
+      head: "feature/pr-head",
+    }, createToolContextForDirectory("/tmp/repo"));
+
+    const result = JSON.parse(output);
+    assert.equal(result.url, "https://github.com/acme/repo/pull/10");
+    assert.equal(result.action, "created");
+    assert.match(executedCommands[0], /--base main/);
+    assert.match(executedCommands[0], /--head feature\/pr-head/);
+  });
+
+  test("creates a PR without head when head is omitted", async () => {
+    const executedCommands: string[] = [];
+    const shell = createMockShell(executedCommands, [
+      {
+        contains: "gh pr create",
+        stdout: "https://github.com/acme/repo/pull/11\n",
+      },
+    ]);
+
+    const tool = createPrSyncTool(shell);
+    const output = await tool.execute({
+      title: "Improve PR creation reliability",
+      body: "Relies on caller-provided branch setup when head is omitted.",
+      base: "main",
+    }, createToolContextForDirectory("/tmp/repo"));
+
+    const result = JSON.parse(output);
+    assert.equal(result.url, "https://github.com/acme/repo/pull/11");
+    assert.equal(result.action, "created");
+    assert.doesNotMatch(executedCommands[0], /--head /);
+  });
+
   test("approves an existing PR without posting a review body", async () => {
     const executedCommands: string[] = [];
     const shell = createMockShell(executedCommands, [

--- a/packages/core/tools/changes-load.ts
+++ b/packages/core/tools/changes-load.ts
@@ -3,10 +3,10 @@ import { mkdtemp, rm } from "node:fs/promises";
 
 import {
   type ChangedFile,
-  ensureGitRef,
   nonEmptyLines,
   parseCommitList,
   parseNameStatus,
+  resolveComparisonRef,
   resolveBaseRef,
   stringifyJson,
   type Shell,
@@ -44,10 +44,11 @@ export function createChangesLoadTool($: Shell) {
       const depthHint = normalizeDepthHint(args.depthHint);
       const branch = await loadCurrentBranch($, ctx.worktree);
       const implicitWorkspaceMode = !args.base?.trim() && !args.head?.trim();
-      const forceWorkspaceMode = args.uncommitted === true;
-      const useWorkspaceMode = forceWorkspaceMode || (implicitWorkspaceMode && (await hasWorktreeChanges($, ctx.worktree)));
+      const comparisonMode = args.uncommitted === true || (implicitWorkspaceMode && (await hasWorktreeChanges($, ctx.worktree)))
+        ? "workspace"
+        : "branch";
 
-      if (useWorkspaceMode) {
+      if (comparisonMode === "workspace") {
         const filesWithDiff = await withTemporaryIndex($, ctx.worktree, async (indexPath) => {
           const files = await loadTemporaryIndexFiles($, ctx.worktree, indexPath);
           return await loadTemporaryIndexDiffs($, ctx.worktree, indexPath, files);
@@ -61,11 +62,11 @@ export function createChangesLoadTool($: Shell) {
       }
 
       const requestedBase = await resolveBaseRef($, ctx.worktree, args.base);
-      let baseRef = await ensureGitRef($, ctx.worktree, requestedBase, {
+      let baseRef = await resolveComparisonRef($, ctx.worktree, requestedBase, {
         depthHint,
       });
       let headRef = args.head?.trim()
-        ? await resolveHeadRef($, ctx.worktree, args.head, depthHint)
+        ? await resolveComparisonRef($, ctx.worktree, args.head, { depthHint })
         : "HEAD";
 
       if (!implicitWorkspaceMode) {
@@ -102,7 +103,7 @@ export function createChangesLoadTool($: Shell) {
       const filesWithDiff = implicitWorkspaceMode
         ? await loadWorkspaceFileDiffs($, ctx.worktree, baseRef, parsedFiles)
         : await loadFileDiffs($, ctx.worktree, baseRef, headRef, parsedFiles);
-      const commits = useWorkspaceMode ? [] : parseCommitList(log.text());
+      const commits = parseCommitList(log.text());
 
       return stringifyJson({
         comparison: `${baseRef}...${headRef}`,
@@ -207,20 +208,9 @@ async function loadFileDiffs(
   headRef: string,
   files: ChangedFile[],
 ) {
-  const enriched: Array<Record<string, unknown>> = [];
-
-  for (const file of files) {
-    if (file.status === "added") {
-      enriched.push(
-        serializeFile(file, {
-        diffOmittedReason: "added file; read current file contents instead",
-        }),
-      );
-      continue;
-    }
-
+  return enrichFileDiffs(files, async (file) => {
     const paths = [file.previousPath, file.path].filter(Boolean) as string[];
-    const proc = paths.length > 1
+    return paths.length > 1
       ? await $`git diff --find-renames --find-copies --unified=3 --no-color --no-ext-diff --no-prefix ${baseRef}...${headRef} -- ${paths[0]} ${paths[1]}`
           .cwd(cwd)
           .quiet()
@@ -229,35 +219,12 @@ async function loadFileDiffs(
           .cwd(cwd)
           .quiet()
           .nothrow();
-
-    if (proc.exitCode !== 0) {
-      enriched.push(serializeFile(file));
-      continue;
-    }
-
-    enriched.push(serializeFile(file, normalizeNativeDiff(file, proc.text())));
-  }
-
-  return enriched;
+  });
 }
 
 async function loadWorkspaceFileDiffs($: Shell, cwd: string, baseRef: string, files: ChangedFile[]) {
-  const enriched: Array<Record<string, unknown>> = [];
-
-  for (const file of files) {
-    if (file.status === "added" || file.status === "untracked") {
-      enriched.push(
-        serializeFile(file, {
-        diffOmittedReason:
-          file.status === "added"
-            ? "added file; read current file contents instead"
-            : "untracked file; read current file contents instead",
-        }),
-      );
-      continue;
-    }
-
-    const proc = [file.previousPath, file.path].filter(Boolean).length > 1
+  return enrichFileDiffs(files, async (file) => {
+    return [file.previousPath, file.path].filter(Boolean).length > 1
       ? await $`git diff --find-renames --find-copies --unified=3 --no-color --no-ext-diff --no-prefix ${baseRef} -- ${file.previousPath!} ${file.path}`
           .cwd(cwd)
           .quiet()
@@ -266,19 +233,27 @@ async function loadWorkspaceFileDiffs($: Shell, cwd: string, baseRef: string, fi
           .cwd(cwd)
           .quiet()
           .nothrow();
-
-    if (proc.exitCode !== 0) {
-      enriched.push(serializeFile(file));
-      continue;
-    }
-
-    enriched.push(serializeFile(file, normalizeNativeDiff(file, proc.text())));
-  }
-
-  return enriched;
+  });
 }
 
 async function loadTemporaryIndexDiffs($: Shell, cwd: string, indexPath: string, files: ChangedFile[]) {
+  return enrichFileDiffs(files, async (file) => {
+    return [file.previousPath, file.path].filter(Boolean).length > 1
+      ? await $`env GIT_INDEX_FILE=${indexPath} git diff --cached --find-renames --find-copies --unified=3 --no-color --no-ext-diff --no-prefix -- ${file.previousPath!} ${file.path}`
+          .cwd(cwd)
+          .quiet()
+          .nothrow()
+      : await $`env GIT_INDEX_FILE=${indexPath} git diff --cached --find-renames --find-copies --unified=3 --no-color --no-ext-diff --no-prefix -- ${file.path}`
+          .cwd(cwd)
+          .quiet()
+          .nothrow();
+  });
+}
+
+async function enrichFileDiffs(
+  files: ChangedFile[],
+  loadDiff: (file: ChangedFile) => Promise<{ exitCode: number; text(): string }>,
+) {
   const enriched: Array<Record<string, unknown>> = [];
 
   for (const file of files) {
@@ -294,15 +269,7 @@ async function loadTemporaryIndexDiffs($: Shell, cwd: string, indexPath: string,
       continue;
     }
 
-    const proc = [file.previousPath, file.path].filter(Boolean).length > 1
-      ? await $`env GIT_INDEX_FILE=${indexPath} git diff --cached --find-renames --find-copies --unified=3 --no-color --no-ext-diff --no-prefix -- ${file.previousPath!} ${file.path}`
-          .cwd(cwd)
-          .quiet()
-          .nothrow()
-      : await $`env GIT_INDEX_FILE=${indexPath} git diff --cached --find-renames --find-copies --unified=3 --no-color --no-ext-diff --no-prefix -- ${file.path}`
-          .cwd(cwd)
-          .quiet()
-          .nothrow();
+    const proc = await loadDiff(file);
 
     if (proc.exitCode !== 0) {
       enriched.push(serializeFile(file));
@@ -374,61 +341,6 @@ function normalizeNativeDiff(file: ChangedFile, rawDiff: string) {
   return undefined;
 }
 
-async function resolveHeadRef($: Shell, cwd: string, input: string, depthHint?: number) {
-  const trimmed = input.trim();
-
-  // If it's already a commit SHA, try to resolve it directly
-  if (/^[0-9a-f]{7,40}$/i.test(trimmed)) {
-    const direct = await $`git rev-parse --verify ${trimmed}`.cwd(cwd).quiet().nothrow();
-    if (direct.exitCode === 0) {
-      return trimmed;
-    }
-
-    // Try to fetch the commit directly
-    const fetchProc = depthHint
-      ? await $`git fetch --no-tags --depth=${Math.max(depthHint, 20)} origin ${trimmed}`
-          .cwd(cwd)
-          .quiet()
-          .nothrow()
-      : await $`git fetch --no-tags origin ${trimmed}`
-          .cwd(cwd)
-          .quiet()
-          .nothrow();
-
-    if (fetchProc.exitCode === 0) {
-      const fetched = await $`git rev-parse --verify ${trimmed}`.cwd(cwd).quiet().nothrow();
-      if (fetched.exitCode === 0) {
-        return trimmed;
-      }
-    }
-  }
-
-  // For branch names, try to resolve as a remote ref first (common in CI)
-  const isBranchName = !trimmed.startsWith("refs/") && !/^[0-9a-f]{7,40}$/i.test(trimmed);
-  if (isBranchName) {
-    const remoteRef = trimmed.startsWith("origin/") ? trimmed : `origin/${trimmed}`;
-    const remoteCheck = await $`git rev-parse --verify ${remoteRef}`.cwd(cwd).quiet().nothrow();
-    if (remoteCheck.exitCode === 0) {
-      return remoteRef;
-    }
-
-    // Try to fetch the branch
-    const branchName = trimmed.startsWith("origin/") ? trimmed.slice(7) : trimmed;
-    const fetchDepth = Math.max(depthHint ?? 0, 50);
-    await $`git fetch --no-tags --depth=${fetchDepth} origin ${branchName}:${remoteRef}`
-      .cwd(cwd)
-      .quiet()
-      .nothrow();
-
-    const afterFetch = await $`git rev-parse --verify ${remoteRef}`.cwd(cwd).quiet().nothrow();
-    if (afterFetch.exitCode === 0) {
-      return remoteRef;
-    }
-  }
-
-  return ensureGitRef($, cwd, trimmed, { depthHint });
-}
-
 async function ensureComparableRefs(
   $: Shell,
   cwd: string,
@@ -445,14 +357,9 @@ async function ensureComparableRefs(
   }
 
   const fetchDepth = Math.max(args.depthHint ?? 0, 50);
-  await hydrateNamedRefHistory($, cwd, args.requestedBase, fetchDepth);
-  if (args.requestedHead?.trim()) {
-    await hydrateNamedRefHistory($, cwd, args.requestedHead, fetchDepth);
-  }
-
-  const baseRef = await ensureGitRef($, cwd, args.requestedBase, { depthHint: fetchDepth });
+  const baseRef = await resolveComparisonRef($, cwd, args.requestedBase, { depthHint: fetchDepth });
   const headRef = args.requestedHead?.trim()
-    ? await resolveHeadRef($, cwd, args.requestedHead, fetchDepth)
+    ? await resolveComparisonRef($, cwd, args.requestedHead, { depthHint: fetchDepth })
     : args.headRef;
 
   return { baseRef, headRef };
@@ -461,18 +368,4 @@ async function ensureComparableRefs(
 async function hasMergeBase($: Shell, cwd: string, baseRef: string, headRef: string) {
   const proc = await $`git merge-base ${baseRef} ${headRef}`.cwd(cwd).quiet().nothrow();
   return proc.exitCode === 0;
-}
-
-async function hydrateNamedRefHistory($: Shell, cwd: string, input: string, depth: number) {
-  const trimmed = input.trim();
-  if (!trimmed || trimmed === "HEAD" || /^[0-9a-f]{7,40}$/i.test(trimmed)) {
-    return;
-  }
-
-  const remoteBranch = trimmed.startsWith("origin/") ? trimmed.slice("origin/".length) : trimmed;
-  const remoteRef = `refs/remotes/origin/${remoteBranch}`;
-  await $`git fetch --no-tags --depth=${depth} origin ${remoteBranch}:${remoteRef}`
-    .cwd(cwd)
-    .quiet()
-    .nothrow();
 }

--- a/packages/core/tools/pr-load.ts
+++ b/packages/core/tools/pr-load.ts
@@ -126,10 +126,6 @@ const REVIEW_THREADS_QUERY = `query($owner: String!, $repo: String!, $number: In
               body
               createdAt
               updatedAt
-              path
-              line
-              startLine
-              url
             }
           }
         }

--- a/packages/core/tools/pr-sync.ts
+++ b/packages/core/tools/pr-sync.ts
@@ -31,6 +31,7 @@ type PrSyncArgs = {
   body?: string;
   description?: string;
   base?: string;
+  head?: string;
   checklists?: Array<{
     name: string;
     items: Array<{
@@ -73,10 +74,6 @@ function renderPrBody(args: PrSyncArgs) {
   return body || undefined;
 }
 
-function normalizeReviewInput(args: PrSyncArgs) {
-  return args.review;
-}
-
 function hasMetadataUpdate(args: PrSyncArgs, body?: string) {
   return Boolean(args.title?.trim() || body || args.base?.trim());
 }
@@ -109,6 +106,12 @@ async function resolvePullRequest($: Shell, worktree: string, ref?: string) {
     number: Number(result.number),
     url: String(result.url),
   };
+}
+
+async function loadRepoContext($: Shell, worktree: string) {
+  const repo = await loadRepoName($, worktree);
+  const [owner, repoName] = repo.split("/");
+  return { repo, owner, repoName };
 }
 
 function normalizeReviewComment(comment: ReviewComment) {
@@ -389,7 +392,7 @@ export function createPrSyncTool($: Shell) {
     },
     async execute(args: PrSyncArgs, ctx: ToolExecutionContext) {
       const body = renderPrBody(args);
-      const review = normalizeReviewInput(args);
+      const review = args.review;
       const metadataUpdate = hasMetadataUpdate(args, body);
       const existingPrActions = requiresExistingPullRequest(args, review);
 
@@ -409,6 +412,10 @@ export function createPrSyncTool($: Shell) {
         const createArgs: string[] = [];
         if (args.base?.trim()) {
           createArgs.push("--base", args.base.trim());
+        }
+        const headBranch = args.head?.trim();
+        if (headBranch) {
+          createArgs.push("--head", headBranch);
         }
         if (args.draft) {
           createArgs.push("--draft");
@@ -432,6 +439,12 @@ export function createPrSyncTool($: Shell) {
 
       const target = await resolvePullRequest($, ctx.worktree, args.refUrl);
       const actions: string[] = [];
+      let repoContext: Awaited<ReturnType<typeof loadRepoContext>> | undefined;
+
+      async function getRepoContext() {
+        repoContext ??= await loadRepoContext($, ctx.worktree);
+        return repoContext;
+      }
 
       if (metadataUpdate) {
         const updated = await updatePullRequest($, ctx.worktree, target.url, {
@@ -460,8 +473,7 @@ export function createPrSyncTool($: Shell) {
 
         // Submit review comments if there are any
         if ((review.comments?.length ?? 0) > 0 || review.body?.trim()) {
-          const repo = await loadRepoName($, ctx.worktree);
-          const [owner, repoName] = repo.split("/");
+          const { owner, repoName } = await getRepoContext();
           
           // Request review from self to clear any previous approval (best-effort)
           await requestReviewFromSelf($, ctx.worktree, owner, repoName, target.number);
@@ -472,8 +484,7 @@ export function createPrSyncTool($: Shell) {
       }
 
       if ((args.replies?.length ?? 0) > 0) {
-        const repo = await loadRepoName($, ctx.worktree);
-        const [owner, repoName] = repo.split("/");
+        const { owner, repoName } = await getRepoContext();
         for (const reply of args.replies ?? []) {
           await postReply($, ctx.worktree, owner, repoName, target.number, reply);
         }

--- a/packages/core/tools/shared.ts
+++ b/packages/core/tools/shared.ts
@@ -183,7 +183,7 @@ export async function gitRefExists($: Shell, cwd: string, ref: string) {
   return proc.exitCode === 0;
 }
 
-export async function ensureGitRef(
+export async function resolveComparisonRef(
   $: Shell,
   cwd: string,
   ref: string,
@@ -194,37 +194,82 @@ export async function ensureGitRef(
     throw new Error("Git ref cannot be empty");
   }
 
-  const directCandidates = [trimmed];
-  if (!trimmed.startsWith("origin/")) {
-    directCandidates.push(`origin/${trimmed}`);
+  if (trimmed === "HEAD") {
+    return trimmed;
   }
 
-  for (const candidate of directCandidates) {
-    if (await gitRefExists($, cwd, candidate)) {
-      return candidate;
+  if (trimmed.startsWith("refs/")) {
+    if (await gitRefExists($, cwd, trimmed)) {
+      return trimmed;
     }
+
+    throw new Error(`Failed to resolve git ref ${ref}`);
+  }
+
+  if (/^[0-9a-f]{7,40}$/i.test(trimmed)) {
+    if (await gitRefExists($, cwd, trimmed)) {
+      return trimmed;
+    }
+
+    const fetchProc = await fetchCommit($, cwd, trimmed, options?.depthHint);
+    if (fetchProc.exitCode === 0 && (await gitRefExists($, cwd, trimmed))) {
+      return trimmed;
+    }
+
+    throw new Error(fetchProc.stderr.toString() || `Failed to resolve git ref ${ref}`);
   }
 
   const remoteBranch = trimmed.startsWith("origin/") ? trimmed.slice("origin/".length) : trimmed;
-  const fetchProc = options?.depthHint
-    ? await $`git fetch --no-tags --depth=${Math.max(options.depthHint, 20)} origin ${remoteBranch}:${`refs/remotes/origin/${remoteBranch}`}`
-        .cwd(cwd)
-        .quiet()
-        .nothrow()
-    : await $`git fetch --no-tags origin ${remoteBranch}:${`refs/remotes/origin/${remoteBranch}`}`
-        .cwd(cwd)
-        .quiet()
-        .nothrow();
+  const remoteCandidate = `origin/${remoteBranch}`;
+  let fetchError = "";
 
-  if (fetchProc.exitCode === 0 && (await gitRefExists($, cwd, `origin/${remoteBranch}`))) {
-    return `origin/${remoteBranch}`;
+  if (await hasRemote($, cwd, "origin")) {
+    const fetchProc = await fetchRemoteBranch($, cwd, remoteBranch, options?.depthHint);
+    fetchError = fetchProc.stderr.toString();
+    if (fetchProc.exitCode === 0 && (await gitRefExists($, cwd, remoteCandidate))) {
+      return remoteCandidate;
+    }
   }
 
   if (await gitRefExists($, cwd, trimmed)) {
     return trimmed;
   }
 
-  throw new Error(fetchProc.stderr.toString() || `Failed to resolve git ref ${ref}`);
+  if (!trimmed.startsWith("origin/") && (await gitRefExists($, cwd, remoteCandidate))) {
+    return remoteCandidate;
+  }
+
+  throw new Error(fetchError || `Failed to resolve git ref ${ref}`);
+}
+
+async function hasRemote($: Shell, cwd: string, remote: string) {
+  const proc = await $`git remote get-url ${remote}`.cwd(cwd).quiet().nothrow();
+  return proc.exitCode === 0;
+}
+
+async function fetchRemoteBranch($: Shell, cwd: string, remoteBranch: string, depthHint?: number) {
+  const remoteRefspec = `+${remoteBranch}:refs/remotes/origin/${remoteBranch}`;
+  return depthHint
+    ? await $`git fetch --no-tags --depth=${Math.max(depthHint, 20)} origin ${remoteRefspec}`
+        .cwd(cwd)
+        .quiet()
+        .nothrow()
+    : await $`git fetch --no-tags origin ${remoteRefspec}`
+        .cwd(cwd)
+        .quiet()
+        .nothrow();
+}
+
+async function fetchCommit($: Shell, cwd: string, commit: string, depthHint?: number) {
+  return depthHint
+    ? await $`git fetch --no-tags --depth=${Math.max(depthHint, 20)} origin ${commit}`
+        .cwd(cwd)
+        .quiet()
+        .nothrow()
+    : await $`git fetch --no-tags origin ${commit}`
+        .cwd(cwd)
+        .quiet()
+        .nothrow();
 }
 
 export function parseIssueReference(source: string) {

--- a/packages/opencode/.opencode/commands/pr/create.md
+++ b/packages/opencode/.opencode/commands/pr/create.md
@@ -131,6 +131,7 @@ Run `git push` and use its output as the source of truth.
 Use `kompass_pr_sync` to create the pull request:
 - Generate a concise title (max 70 chars) summarizing the change and store it as `<pr-title>`
 - Generate a short description that briefly describes the intent and scope
+- Pass `<current-branch>` as `head` when it is available so PR creation does not depend on local upstream inference
 - Generate a compact checklist that mirrors the same human-facing structure used for the ticket summary:
   - group delivered work into 2-4 functional or outcome-focused sections
   - use concise section names instead of generic labels like `Changes`

--- a/packages/opencode/.opencode/commands/pr/review.md
+++ b/packages/opencode/.opencode/commands/pr/review.md
@@ -56,7 +56,9 @@ Before publishing, derive: `<has-inline-comments>`, `<has-body-note>`, `<publish
 **Grading and Publishing Rules:**
 1. Assign a grade based on code quality (1-5 stars)
 2. If grade is below `★★★★★` without supporting feedback (inline comments or body note), you MUST add feedback - never publish a low grade without explaining why
-3. **NEVER post a review with `★★★★★`** - if the final grade is 5 stars, approve the PR instead
+
+3. If the final grade is `★★★★★`, publish it as review feedback instead of approving the PR
+
 4. If there are issues (grade < 5 stars), create inline comments on specific lines
 
 **Inline comment format:**
@@ -70,9 +72,13 @@ For multi-line: add `startLine`. For deleted lines: use `side: "LEFT"`.
 
 ### Publish Review
 
+
 **If `<publish-grade>` is `★★★★★`:**
-- Already approved → skip
-- Otherwise → `kompass_pr_sync` with `refUrl: <pr-context.pr.url>` and only `review.approve: true`
+- Pass `refUrl: <pr-context.pr.url>`
+- `review.body`: `★★★★★` plus any optional positive summary notes
+- Do not pass `review.approve`
+- Do not pass any other fields
+
 
 **If `<publish-grade>` < `★★★★★`:**
 - Pass `refUrl: <pr-context.pr.url>`
@@ -88,21 +94,9 @@ Use `<ticket-context>` and `<additional-context>` to judge whether the PR meets 
 
 ## Output
 
-When approved:
-```
-PR approved for #<pr-context.pr.number>
 
-- PR URL: <pr-context.pr.url>
-```
 
-When approval skipped (already approved):
-```
-Approval skipped for PR #<pr-context.pr.number>
-
-- Reason: current head already approved
-```
-
-When review published (grade < 5 stars with feedback):
+When review published:
 ```
 Review submitted for PR #<pr-context.pr.number>
 

--- a/packages/opencode/.opencode/kompass.jsonc
+++ b/packages/opencode/.opencode/kompass.jsonc
@@ -22,7 +22,8 @@
       "enabled": true
     },
     "pr/review": {
-      "enabled": true
+      "enabled": true,
+      "approve": false
     },
     "reload": {
       "enabled": true

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -315,6 +315,7 @@ Create, update, or review a GitHub pull request with structured checklists.
 - `body` (optional): raw PR body override
 - `description` (optional): short PR description rendered above checklist sections
 - `base` (optional): base branch to merge into
+- `head` (optional): head branch to use when creating a PR
 - `checklists` (optional): structured checklist sections (e.g., Testing, Summary)
 - `draft` (optional): create as draft PR
 - `refUrl` (optional): PR URL to update instead of creating new

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -247,6 +247,7 @@ const opencodeToolCreators = {
         body: tool.schema.string().describe("PR body override").optional(),
         description: tool.schema.string().describe("Short PR description rendered above checklist sections").optional(),
         base: tool.schema.string().describe("Base branch to merge into").optional(),
+        head: tool.schema.string().describe("Head branch to use when creating a PR").optional(),
         checklists: tool.schema.array(tool.schema.object({
           name: tool.schema.string().describe("Checklist section name"),
           items: tool.schema.array(tool.schema.object({

--- a/packages/opencode/scripts/compile.ts
+++ b/packages/opencode/scripts/compile.ts
@@ -142,7 +142,13 @@ async function main() {
   };
   const configOutput = {
     commands: Object.fromEntries(
-      Object.keys(compiledCommands).map((name) => [name, { enabled: true }]),
+      Object.entries(compiledCommands).map(([name, command]) => [
+        name,
+        {
+          enabled: true,
+          ...(command.config ? command.config : {}),
+        },
+      ]),
     ),
     agents: Object.fromEntries(
       Object.keys(resolvedAgents).map((name) => [name, { enabled: true }]),

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -181,7 +181,7 @@ describe("applyCommandsConfig", () => {
       }
     });
 
-    test("replaces {{dev-flow}} placeholder with component content", async () => {
+    test("renders Eta partial content into commands", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};
 
@@ -191,11 +191,10 @@ describe("applyCommandsConfig", () => {
       assert.ok(cfg.command!["dev"]);
       // Should contain the actual content from dev-flow.md
       assert.match(cfg.command!["dev"].template, /Development Flow Navigation Guide/);
-      // Should NOT contain the placeholder
-      assert.doesNotMatch(cfg.command!["dev"].template, /\{\{dev-flow\}\}/);
+      assert.doesNotMatch(cfg.command!["dev"].template, /<%/);
     });
 
-    test("replaces multiple component placeholders in same template", async () => {
+    test("renders commands with all partials expanded", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};
 
@@ -203,8 +202,7 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       assert.ok(cfg.command!["dev"]);
-      // dev.md uses {{dev-flow}} component
-      assert.doesNotMatch(cfg.command!["dev"].template, /\{\{dev-flow\}\}/);
+      assert.doesNotMatch(cfg.command!["dev"].template, /<%/);
     });
 
     test("pr/fix command does not use pr-fix component", async () => {
@@ -243,19 +241,54 @@ describe("applyCommandsConfig", () => {
       assert.doesNotMatch(cfg.command!["pr/review"].template, /\{\{code-review\}\}/);
       assert.match(cfg.command!["pr/review"].template, /## Goal/);
       assert.match(cfg.command!["pr/review"].template, /Review a GitHub pull request/);
+      assert.doesNotMatch(cfg.command!["pr/review"].template, /<%/);
+      assert.match(
+        cfg.command!["pr/review"].template,
+        /publish it as review feedback instead of approving the PR/,
+      );
+      assert.doesNotMatch(cfg.command!["pr/review"].template, /only `review\.approve: true`/);
     });
 
-    test("preserves unknown placeholders when component not found", async () => {
+    test("pr/review supports disabling approval via template data", async () => {
+      delete process.env.CI;
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-pr-review-template-data-"));
+
+      try {
+        await writeFile(
+          path.join(tempDir, "kompass.jsonc"),
+          `{
+            "commands": {
+              "pr/review": {
+                "approve": false
+              }
+            }
+          }`,
+        );
+
+        const cfg: { command?: Record<string, { template: string }> } = {};
+
+        await applyCommandsConfig(cfg as never, tempDir);
+
+        assert.ok(cfg.command);
+        assert.match(
+          cfg.command!["pr/review"].template,
+          /publish it as review feedback instead of approving the PR/,
+        );
+        assert.match(cfg.command!["pr/review"].template, /`★★★★★` plus any optional positive summary notes/);
+        assert.doesNotMatch(cfg.command!["pr/review"].template, /only `review\.approve: true`/);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    test("renders templates without leaving Eta tags behind", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};
 
-      // This test verifies the embedComponents function preserves unknown placeholders
-      // by checking that the command registration still works even with unknown components
       await applyCommandsConfig(cfg as never, process.cwd());
 
       assert.ok(cfg.command);
-      // All default commands should still be registered
-      assert.ok(cfg.command!["dev"]);
+      assert.doesNotMatch(cfg.command!["pr/create"].template, /<%/);
     });
   });
 
@@ -367,9 +400,7 @@ describe("applyCommandsConfig", () => {
       assert.match(shipTemplate, /Store the subagent result as `<pr-result>`/);
       assert.match(shipTemplate, /<task agent="general" command="\/pr\/create">/);
 
-      // Verify no component placeholders remain (all should be expanded)
-      const remainingPlaceholders = shipTemplate.match(/\{\{[\w-]+\}\}/g);
-      assert.strictEqual(remainingPlaceholders, null, `Found unexpanded placeholders: ${remainingPlaceholders?.join(', ')}`);
+      assert.doesNotMatch(shipTemplate, /<%/);
     });
 
     test("embeds all expected components in dev command", async () => {
@@ -387,8 +418,7 @@ describe("applyCommandsConfig", () => {
       assert.match(devTemplate, /## Goal/);
       assert.match(devTemplate, /Implement a feature or fix/);
       
-      // Should not have any remaining placeholders
-      assert.doesNotMatch(devTemplate, /\{\{[\w-]+\}\}/);
+      assert.doesNotMatch(devTemplate, /<%/);
     });
 
     test("embeds all expected components in pr/create command", async () => {
@@ -406,8 +436,7 @@ describe("applyCommandsConfig", () => {
       assert.match(prCreateTemplate, /Interpret Arguments/);
       assert.match(prCreateTemplate, /Load & Analyze Changes/);
       
-      // Should not have any remaining placeholders
-      assert.doesNotMatch(prCreateTemplate, /\{\{[\w-]+\}\}/);
+      assert.doesNotMatch(prCreateTemplate, /<%/);
     });
 
     test("embeds all expected components in ticket/create command", async () => {
@@ -423,7 +452,7 @@ describe("applyCommandsConfig", () => {
       assert.match(ticketCreateTemplate, /Create a ticket that summarizes the work returned by the current change comparison/);
       assert.match(ticketCreateTemplate, /Load & Analyze Changes/);
 
-      assert.doesNotMatch(ticketCreateTemplate, /\{\{[\w-]+\}\}/);
+      assert.doesNotMatch(ticketCreateTemplate, /<%/);
     });
 
     test("embeds all expected components in ticket/dev command", async () => {
@@ -441,13 +470,12 @@ describe("applyCommandsConfig", () => {
       assert.match(ticketDevTemplate, /## Goal/);
       assert.match(ticketDevTemplate, /Implement a ticket/);
       
-      // Should not have any remaining placeholders
-      assert.doesNotMatch(ticketDevTemplate, /\{\{[\w-]+\}\}/);
+      assert.doesNotMatch(ticketDevTemplate, /<%/);
     });
   });
 
-  describe("parameterized component replacement", () => {
-    test("replaces {{param:name}} with provided parameter value", async () => {
+  describe("partial locals", () => {
+    test("passes locals into Eta partials", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};
 
@@ -455,15 +483,12 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       
-      // commit command uses parameterized change-summary
       const commitTemplate = cfg.command!["commit"].template;
-      // Should have replaced the parameter
       assert.match(commitTemplate, /pass `uncommitted: true`/);
-      // Should NOT have {{param:...}} placeholders
-      assert.doesNotMatch(commitTemplate, /\{\{param:[\w-]+\}\}/);
+      assert.doesNotMatch(commitTemplate, /<%/);
     });
 
-    test("uses different parameter values for different commands", async () => {
+    test("uses different local values for different commands", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};
 
@@ -474,20 +499,17 @@ describe("applyCommandsConfig", () => {
       const commitTemplate = cfg.command!["commit"].template;
       const prCreateTemplate = cfg.command!["pr/create"].template;
       
-      // commit should mention uncommitted
       assert.match(commitTemplate, /pass `uncommitted: true`/);
-      // pr/create should mention base branch detection
       assert.match(prCreateTemplate, /base branch/);
     });
 
-    test("preserves {{param:...}} when parameter not provided", async () => {
+    test("renders commands that do not need partial locals", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};
 
       await applyCommandsConfig(cfg as never, process.cwd());
 
       assert.ok(cfg.command);
-      // Commands without parameters should still work
       assert.ok(cfg.command!["dev"]);
       assert.ok(cfg.command!["pr/review"]);
     });


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Adds Eta-backed command templating so reusable components, conditional content, and command-specific config can flow through core command definitions and compiled OpenCode output.

## Checklist
### Shared templating
- [x] Support Eta partial includes and conditional command content
- [x] Register reusable components during template rendering

### Config and compilation
- [x] Carry command template config and component paths through merged config
- [x] Preserve generated OpenCode command output for the new template model

### Docs and coverage
- [x] Document Eta authoring rules for commands and components
- [x] Add tests for component rendering, command defaults, PR head handling, and config resolution

### Validation
- [x] Verify shared components render correctly inside compiled command templates
- [x] Confirm PR creation passes explicit head branches when provided