### PR TITLE
Make validation guidance configurable

### DIFF
--- a/kompass.jsonc
+++ b/kompass.jsonc
@@ -3,6 +3,10 @@
 
   "shared": {
     "prApprove": false,
+    "validation": [
+      "Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist",
+      "If a category of validation is not available in the project, note it explicitly instead of inventing a command"
+    ]
   },
 
   // Command config is now object-based so each entry can be toggled or customized.

--- a/kompass.schema.json
+++ b/kompass.schema.json
@@ -18,6 +18,13 @@
         "prApprove": {
           "type": "boolean",
           "description": "Whether PR review workflows may submit approvals instead of five-star review comments"
+        },
+        "validation": {
+          "type": "array",
+          "description": "Validation guidance lines rendered into command templates",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/packages/core/commands/dev.md
+++ b/packages/core/commands/dev.md
@@ -32,11 +32,11 @@ $ARGUMENTS
 
 ### Validate Changes
 
-- Run the required validation commands for edits made in this session:
-  - `bun run compile`
-  - `bun run typecheck`
-  - `bun run test`
-- Store the results as `<compile-status>`, `<typecheck-status>`, and `<test-status>`
+- Run the most relevant available validation for edits made in this session
+<% for (const line of it.config.shared.validation) { -%>
+- <%= line %>
+<% } -%>
+- Store the collected results as `<validation-results>`
 
 ### Prepare PR Handoff
 
@@ -56,9 +56,7 @@ When the implementation is ready for PR creation, display:
 Implementation ready: <request-summary>
 
 Validation:
-- Compile: <compile-status>
-- Typecheck: <typecheck-status>
-- Test: <test-status>
+<validation-results>
 
 Next: create a PR for <branch>
 ```

--- a/packages/core/commands/learn.md
+++ b/packages/core/commands/learn.md
@@ -30,7 +30,7 @@ $ARGUMENTS
   - Non-obvious configuration, environment variables, or flags
   - Debugging breakthroughs when error messages were misleading
   - API or tool quirks and workarounds
-  - Build or test commands not documented elsewhere
+  - Project-specific validation or verification steps not documented elsewhere
   - Architectural decisions and constraints
   - Files that must change together
   - Environment-specific behavior

--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -45,12 +45,13 @@ Do not blindly follow every suggestion—some may lead you off course.
 
 ### Validate Changes
 
-Run validation commands:
-- Compile: `bun run compile`
-- Type checking: `bun run typecheck`
-- Tests: `bun run test`
-- Confirm fixes address the feedback
-- Store the overall test result as `<tests-passing>` with value `yes` or `no`
+Run the most relevant available validation for the fixes:
+<% for (const line of it.config.shared.validation) { -%>
+- <%= line %>
+<% } -%>
+- Confirm the fixes address the feedback
+- Store the collected validation details as `<validation-results>`
+- Store the overall validation outcome as `<validation-passing>` with value `yes` or `no`
 
 ### Push Updates
 
@@ -93,6 +94,7 @@ PR fix complete for #<pr-context.pr.number>
 - Status: complete, no additional steps needed
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>
-- Tests passing: <tests-passing>
+- Validation passing: <validation-passing>
+- Validation details: <validation-results>
 - Pushed: <pushed>
 ```

--- a/packages/core/commands/rmslop.md
+++ b/packages/core/commands/rmslop.md
@@ -48,12 +48,12 @@ $ARGUMENTS
 
 ### Validate
 
-- Run the required validation commands for the edited work in this session:
-  - `bun run compile`
-  - `bun run typecheck`
-  - `bun run test`
+- Run the most relevant available validation for the edited work in this session
+<% for (const line of it.config.shared.validation) { -%>
+- <%= line %>
+<% } -%>
 - Confirm the cleaned-up code still works correctly before committing
-- Store the overall validation result as `<validation-status>`
+- Store the collected validation summary as `<validation-status>`
 
 ### Commit Changes
 

--- a/packages/core/commands/ticket/dev.md
+++ b/packages/core/commands/ticket/dev.md
@@ -28,11 +28,11 @@ $ARGUMENTS
 
 ### Validate Changes
 
-- Run the required validation commands for edits made in this session:
-  - `bun run compile`
-  - `bun run typecheck`
-  - `bun run test`
-- Store the results as `<compile-status>`, `<typecheck-status>`, and `<test-status>`
+- Run the most relevant available validation for edits made in this session
+<% for (const line of it.config.shared.validation) { -%>
+- <%= line %>
+<% } -%>
+- Store the collected results as `<validation-results>`
 
 ### Delegate PR Creation
 
@@ -65,7 +65,5 @@ Implemented ticket: <ticket-summary>
 
 PR: <pr-url>
 Validation:
-- Compile: <compile-status>
-- Typecheck: <typecheck-status>
-- Test: <test-status>
+<validation-results>
 ```

--- a/packages/core/kompass.jsonc
+++ b/packages/core/kompass.jsonc
@@ -3,6 +3,10 @@
 
   "shared": {
     "prApprove": false,
+    "validation": [
+      "Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist",
+      "If a category of validation is not available in the project, note it explicitly instead of inventing a command"
+    ]
   },
 
   // Command config is now object-based so each entry can be toggled or customized.

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -95,6 +95,7 @@ export interface SkillIdentity {
 export interface KompassConfig {
   shared?: {
     prApprove?: boolean;
+    validation?: string[];
   };
   commands?: {
     branch?: CommandConfig;
@@ -155,6 +156,7 @@ export interface KompassConfig {
 export interface MergedKompassConfig {
   shared: {
     prApprove: boolean;
+    validation: string[];
   };
   commands: {
     enabled: string[];
@@ -575,6 +577,7 @@ export function mergeWithDefaults(
   return {
     shared: {
       prApprove: config?.shared?.prApprove ?? false,
+      validation: config?.shared?.validation ?? [],
     },
     commands: {
       enabled: getEnabledNames(

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -32,6 +32,34 @@ describe("config loading", () => {
     }
   });
 
+  test("parses validation strings in jsonc config files", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-validation-"));
+
+    try {
+      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+      await writeFile(
+        path.join(tempDir, ".opencode", "kompass.jsonc"),
+        `{
+          "shared": {
+            "validation": [
+              "Run lint if available",
+              "Run tests if available"
+            ]
+          }
+        }`,
+      );
+
+      const config = await loadKompassConfig(tempDir);
+
+      assert.equal(
+        JSON.stringify(config.shared?.validation),
+        JSON.stringify(["Run lint if available", "Run tests if available"]),
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("prefers project config files in documented order", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-order-"));
 
@@ -106,7 +134,10 @@ describe("config loading", () => {
 describe("object-based config", () => {
   test("supports command, agent, and component entry toggles", () => {
     const config = mergeWithDefaults({
-      shared: { prApprove: false },
+      shared: {
+        prApprove: false,
+        validation: ["Run custom validation"],
+      },
       commands: {
         dev: { enabled: false },
         review: { enabled: true, template: "commands/custom-review.md" },
@@ -125,6 +156,7 @@ describe("object-based config", () => {
     assert.equal(config.commands.enabled.includes("review"), true);
     assert.equal(config.commands.templates.review, "commands/custom-review.md");
     assert.equal(config.shared.prApprove, false);
+    assert.deepEqual(config.shared.validation, ["Run custom validation"]);
     assert.deepEqual(config.agents.navigator.permission, {
       task: "deny",
       todowrite: "deny",
@@ -162,6 +194,7 @@ describe("command defaults", () => {
     const config = mergeWithDefaults(null);
 
     assert.equal(config.agents.enabled.includes("navigator"), true);
+    assert.deepEqual(config.shared.validation, []);
     assert.deepEqual(config.agents.navigator.permission, {
       edit: "deny",
       task: "allow",

--- a/packages/opencode/.opencode/commands/dev.md
+++ b/packages/opencode/.opencode/commands/dev.md
@@ -43,11 +43,10 @@ $ARGUMENTS
 
 ### Validate Changes
 
-- Run the required validation commands for edits made in this session:
-  - `bun run compile`
-  - `bun run typecheck`
-  - `bun run test`
-- Store the results as `<compile-status>`, `<typecheck-status>`, and `<test-status>`
+- Run the most relevant available validation for edits made in this session
+- Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist
+- If a category of validation is not available in the project, note it explicitly instead of inventing a command
+- Store the collected results as `<validation-results>`
 
 ### Prepare PR Handoff
 
@@ -67,9 +66,7 @@ When the implementation is ready for PR creation, display:
 Implementation ready: <request-summary>
 
 Validation:
-- Compile: <compile-status>
-- Typecheck: <typecheck-status>
-- Test: <test-status>
+<validation-results>
 
 Next: create a PR for <branch>
 ```

--- a/packages/opencode/.opencode/commands/learn.md
+++ b/packages/opencode/.opencode/commands/learn.md
@@ -35,7 +35,7 @@ $ARGUMENTS
   - Non-obvious configuration, environment variables, or flags
   - Debugging breakthroughs when error messages were misleading
   - API or tool quirks and workarounds
-  - Build or test commands not documented elsewhere
+  - Project-specific validation or verification steps not documented elsewhere
   - Architectural decisions and constraints
   - Files that must change together
   - Environment-specific behavior

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -50,12 +50,12 @@ Do not blindly follow every suggestion—some may lead you off course.
 
 ### Validate Changes
 
-Run validation commands:
-- Compile: `bun run compile`
-- Type checking: `bun run typecheck`
-- Tests: `bun run test`
-- Confirm fixes address the feedback
-- Store the overall test result as `<tests-passing>` with value `yes` or `no`
+Run the most relevant available validation for the fixes:
+- Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist
+- If a category of validation is not available in the project, note it explicitly instead of inventing a command
+- Confirm the fixes address the feedback
+- Store the collected validation details as `<validation-results>`
+- Store the overall validation outcome as `<validation-passing>` with value `yes` or `no`
 
 ### Push Updates
 
@@ -98,6 +98,7 @@ PR fix complete for #<pr-context.pr.number>
 - Status: complete, no additional steps needed
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>
-- Tests passing: <tests-passing>
+- Validation passing: <validation-passing>
+- Validation details: <validation-results>
 - Pushed: <pushed>
 ```

--- a/packages/opencode/.opencode/commands/rmslop.md
+++ b/packages/opencode/.opencode/commands/rmslop.md
@@ -53,12 +53,11 @@ $ARGUMENTS
 
 ### Validate
 
-- Run the required validation commands for the edited work in this session:
-  - `bun run compile`
-  - `bun run typecheck`
-  - `bun run test`
+- Run the most relevant available validation for the edited work in this session
+- Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist
+- If a category of validation is not available in the project, note it explicitly instead of inventing a command
 - Confirm the cleaned-up code still works correctly before committing
-- Store the overall validation result as `<validation-status>`
+- Store the collected validation summary as `<validation-status>`
 
 ### Commit Changes
 

--- a/packages/opencode/.opencode/commands/ticket/dev.md
+++ b/packages/opencode/.opencode/commands/ticket/dev.md
@@ -39,11 +39,10 @@ $ARGUMENTS
 
 ### Validate Changes
 
-- Run the required validation commands for edits made in this session:
-  - `bun run compile`
-  - `bun run typecheck`
-  - `bun run test`
-- Store the results as `<compile-status>`, `<typecheck-status>`, and `<test-status>`
+- Run the most relevant available validation for edits made in this session
+- Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist
+- If a category of validation is not available in the project, note it explicitly instead of inventing a command
+- Store the collected results as `<validation-results>`
 
 ### Delegate PR Creation
 
@@ -76,7 +75,5 @@ Implemented ticket: <ticket-summary>
 
 PR: <pr-url>
 Validation:
-- Compile: <compile-status>
-- Typecheck: <typecheck-status>
-- Test: <test-status>
+<validation-results>
 ```

--- a/packages/opencode/.opencode/kompass.jsonc
+++ b/packages/opencode/.opencode/kompass.jsonc
@@ -1,6 +1,10 @@
 {
   "shared": {
-    "prApprove": true
+    "prApprove": true,
+    "validation": [
+      "Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist",
+      "If a category of validation is not available in the project, note it explicitly instead of inventing a command"
+    ]
   },
   "commands": {
     "branch": {

--- a/packages/opencode/kompass.jsonc
+++ b/packages/opencode/kompass.jsonc
@@ -3,6 +3,10 @@
 
   "shared": {
     "prApprove": false,
+    "validation": [
+      "Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist",
+      "If a category of validation is not available in the project, note it explicitly instead of inventing a command"
+    ]
   },
 
   // Command config is now object-based so each entry can be toggled or customized.

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -183,6 +183,40 @@ describe("applyCommandsConfig", () => {
       }
     });
 
+    test("renders shared validation guidance from config", async () => {
+      delete process.env.CI;
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-validation-guidance-"));
+
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "validation": [
+                "Run npm test if available",
+                "Run npm run lint if available"
+              ]
+            }
+          }`,
+        );
+
+        const cfg: { command?: Record<string, { template: string }> } = {};
+
+        await applyCommandsConfig(cfg as never, tempDir);
+
+        assert.ok(cfg.command);
+        assert.match(cfg.command!["dev"].template, /Run npm test if available/);
+        assert.match(cfg.command!["dev"].template, /Run npm run lint if available/);
+        assert.doesNotMatch(
+          cfg.command!["dev"].template,
+          /Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
     test("renders Eta partial content into commands", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Make command validation guidance configurable through shared Kompass config so projects can render project-specific verification steps instead of hard-coded compile, typecheck, and test instructions.

## Checklist
### Validation config support
- [x] Add shared `validation` config support to schema and merged config types
- [x] Load configured validation guidance with a safe empty default

### Command template updates
- [x] Render shared validation guidance in command templates that prepare or report validation
- [x] Update validation wording to collect flexible validation results instead of fixed command statuses

### Coverage
- [x] Add tests for parsing validation config and rendering it into generated command templates

### Validation
- [x] Verify that custom shared validation lines are loaded from project config files
- [x] Confirm that rendered command templates include configured validation guidance instead of hard-coded steps
- [x] Check that default config still works with an empty validation list