### PR TITLE
Clarify ticket-driven command orchestration

### DIFF
--- a/packages/core/commands/pr/create.md
+++ b/packages/core/commands/pr/create.md
@@ -47,9 +47,11 @@ $ARGUMENTS
 ### Resolve Ticket
 
 - If `<ticket-mode>` is already `auto`, `provided`, or `skip`, do not ask a follow-up question
-- Otherwise, if the `question` tool is available, this step is mandatory:
+- Otherwise, if the `question` tool is available, this step is mandatory whenever the user did not already provide ticket handling through `<arguments>`:
   - Ask exactly one `question` before creating a ticket or PR
-  - Do not infer a default ticket mode
+  - This includes the common case where no ticket-related argument was provided at all
+  - Do not infer, assume, or default to any ticket mode while the `question` tool is available
+  - Never choose `skip` unless the user explicitly selects `Skip` or explicitly asks to skip ticket mention in `<arguments>`
   - Do not proceed to `Prepare Ticket Reference`, `Push Branch`, or `Create PR` until the answer is resolved
   - Ask with:
     - header `Provide Ticket`
@@ -60,6 +62,7 @@ $ARGUMENTS
     - custom answers enabled so the user can paste a ticket URL or ticket reference directly
 - Otherwise, if the `question` tool is not available:
   - Do not ask a follow-up question
+  - Only in this case may the workflow continue without user input
   - Store `<ticket-mode>` as `skip`
   - Store `<ticket-url>` as `SKIPPED`
   - Continue without blocking

--- a/packages/core/commands/ship.md
+++ b/packages/core/commands/ship.md
@@ -20,7 +20,6 @@ $ARGUMENTS
 ### Ensure Feature Branch
 
 <task agent="general" command="/branch">
-
 Branch naming guidance: <branch-context>
 </task>
 
@@ -32,7 +31,6 @@ Branch naming guidance: <branch-context>
 ### Delegate Commit
 
 <task agent="general" command="/commit">
-
 Additional context: <additional-context>
 </task>
 
@@ -45,7 +43,6 @@ Additional context: <additional-context>
 ### Delegate PR Creation
 
 <task agent="general" command="/pr/create">
-
 Base branch: <base>
 Additional context: <additional-context>
 </task>

--- a/packages/core/commands/ticket/dev.md
+++ b/packages/core/commands/ticket/dev.md
@@ -1,6 +1,6 @@
 ## Goal
 
-Implement a ticket and create a pull request for the completed work.
+Implement a ticket by orchestrating development, branching, commit-and-push, and PR creation.
 
 ## Workflow
 
@@ -26,36 +26,63 @@ $ARGUMENTS
 
 <%~ include("@dev-flow") %>
 
-### Validate Changes
+### Delegate Implementation
 
-- Run the most relevant available validation for edits made in this session
-<% for (const line of it.config.shared.validation) { -%>
-- <%= line %>
-<% } -%>
-- Store the collected results as `<validation-results>`
+- Before delegating, send the exact task block below
 
-### Delegate PR Creation
-
-- The subagent receives `<ticket-ref>`, `<ticket-context>`, and `<additional-context>`
-- Define `<prompt>` as:
-
-<prompt>
-/pr/create
-
+<task agent="general" command="/dev">
 Ticket reference: <ticket-ref>
 Ticket context: <ticket-context>
 Additional context: <additional-context>
-</prompt>
+</task>
 
-- Call subagent `@general` with `<prompt>`
-- Do not paraphrase or prepend extra text
-- Store the subagent result as `<pr-result>`
+- Store the result as `<implementation-result>`
+- If `<implementation-result>` is blocked or incomplete, STOP and report the implementation blocker
+
+### Delegate Branch Creation
+
+- Before delegating, send the exact task block below
+
+<task agent="general" command="/branch">
+Branch naming guidance: <ticket-summary>
+Additional context: <additional-context>
+</task>
+
+- Store the result as `<branch-result>`
+- If `<branch-result>` is blocked or incomplete, STOP and report the branch blocker
+- If `<branch-result>` says branching was skipped because the current branch already looks like a work branch, continue
+
+### Delegate Commit And Push
+
+- Before delegating, send the exact task block below
+
+<task agent="general" command="/commit-and-push">
+Ticket reference: <ticket-ref>
+Ticket summary: <ticket-summary>
+Additional context: <additional-context>
+</task>
+
+- Store the result as `<commit-result>`
+- If `<commit-result>` is blocked or incomplete, STOP and report the commit or push blocker
+- If `<commit-result>` says there was nothing to commit or push, continue to PR creation so already-committed branch work can still be shipped
+
+### Delegate PR Creation
+
+- Before delegating, send the exact task block below
+
+<task agent="general" command="/pr/create">
+Ticket reference: <ticket-ref>
+Ticket context: <ticket-context>
+Additional context: <additional-context>
+</task>
+
+- Store the result as `<pr-result>`
 - If `<pr-result>` is blocked or incomplete, STOP and report the PR blocker
 - Otherwise, continue and store the resulting PR URL as `<pr-url>`
 
 ## Additional Context
 
-Use `<additional-context>` to refine scope, sequencing, and tradeoffs while implementing `<ticket-context>`.
+Use `<additional-context>` to refine scope, sequencing, and tradeoffs across the delegated `/dev`, `/branch`, `/commit-and-push`, and `/pr/create` steps.
 
 ## Output
 
@@ -63,7 +90,8 @@ When the ticket work is complete, display:
 ```
 Implemented ticket: <ticket-summary>
 
+Implementation: <implementation-result>
+Branch: <branch-result>
+Commit and push: <commit-result>
 PR: <pr-url>
-Validation:
-<validation-results>
 ```

--- a/packages/core/commands/todo.md
+++ b/packages/core/commands/todo.md
@@ -35,7 +35,6 @@ $ARGUMENTS
 ### Delegate Planning
 
 <task agent="planner" command="/ticket/plan">
-
 Task: <task>
 Task context: <task-context>
 Additional context: <additional-context>
@@ -57,7 +56,6 @@ Additional context: <additional-context>
 - custom answers enabled so the user can provide specific plan changes
 - If the user requests changes, store that feedback as `<user-answer>`
 <task agent="planner" command="/ticket/plan">
-
 Task: <task>
 Task context: <task-context>
 Current plan: <plan>
@@ -73,7 +71,6 @@ Additional context: <additional-context>
 ### Delegate Implementation
 
 <task agent="general" command="/dev">
-
 Plan: <plan>
 Task: <task>
 Task context: <task-context>
@@ -86,7 +83,6 @@ Additional context: <additional-context>
 ### Delegate Commit
 
 <task agent="general" command="/commit">
-
 Task: <task>
 Additional context: <additional-context>
 </task>

--- a/packages/opencode/.opencode/commands/pr/create.md
+++ b/packages/opencode/.opencode/commands/pr/create.md
@@ -72,9 +72,11 @@ $ARGUMENTS
 ### Resolve Ticket
 
 - If `<ticket-mode>` is already `auto`, `provided`, or `skip`, do not ask a follow-up question
-- Otherwise, if the `question` tool is available, this step is mandatory:
+- Otherwise, if the `question` tool is available, this step is mandatory whenever the user did not already provide ticket handling through `<arguments>`:
   - Ask exactly one `question` before creating a ticket or PR
-  - Do not infer a default ticket mode
+  - This includes the common case where no ticket-related argument was provided at all
+  - Do not infer, assume, or default to any ticket mode while the `question` tool is available
+  - Never choose `skip` unless the user explicitly selects `Skip` or explicitly asks to skip ticket mention in `<arguments>`
   - Do not proceed to `Prepare Ticket Reference`, `Push Branch`, or `Create PR` until the answer is resolved
   - Ask with:
     - header `Provide Ticket`
@@ -85,6 +87,7 @@ $ARGUMENTS
     - custom answers enabled so the user can paste a ticket URL or ticket reference directly
 - Otherwise, if the `question` tool is not available:
   - Do not ask a follow-up question
+  - Only in this case may the workflow continue without user input
   - Store `<ticket-mode>` as `skip`
   - Store `<ticket-url>` as `SKIPPED`
   - Continue without blocking

--- a/packages/opencode/.opencode/commands/ship.md
+++ b/packages/opencode/.opencode/commands/ship.md
@@ -25,7 +25,6 @@ $ARGUMENTS
 ### Ensure Feature Branch
 
 <task agent="general" command="/branch">
-
 Branch naming guidance: <branch-context>
 </task>
 
@@ -37,7 +36,6 @@ Branch naming guidance: <branch-context>
 ### Delegate Commit
 
 <task agent="general" command="/commit">
-
 Additional context: <additional-context>
 </task>
 
@@ -50,7 +48,6 @@ Additional context: <additional-context>
 ### Delegate PR Creation
 
 <task agent="general" command="/pr/create">
-
 Base branch: <base>
 Additional context: <additional-context>
 </task>

--- a/packages/opencode/.opencode/commands/ticket/dev.md
+++ b/packages/opencode/.opencode/commands/ticket/dev.md
@@ -5,7 +5,7 @@ agent: build
 
 ## Goal
 
-Implement a ticket and create a pull request for the completed work.
+Implement a ticket by orchestrating development, branching, commit-and-push, and PR creation.
 
 ## Workflow
 
@@ -37,35 +37,63 @@ $ARGUMENTS
 - Validate the path with targeted checks before handing off to PR creation
 - Surface any detours or follow-up destinations that should stay off the current route
 
-### Validate Changes
+### Delegate Implementation
 
-- Run the most relevant available validation for edits made in this session
-- Prefer project-native checks such as changed-area tests, linting, type checking, build verification, or other documented validation steps when they exist
-- If a category of validation is not available in the project, note it explicitly instead of inventing a command
-- Store the collected results as `<validation-results>`
+- Before delegating, send the exact task block below
 
-### Delegate PR Creation
-
-- The subagent receives `<ticket-ref>`, `<ticket-context>`, and `<additional-context>`
-- Define `<prompt>` as:
-
-<prompt>
-/pr/create
-
+<task agent="general" command="/dev">
 Ticket reference: <ticket-ref>
 Ticket context: <ticket-context>
 Additional context: <additional-context>
-</prompt>
+</task>
 
-- Call subagent `@general` with `<prompt>`
-- Do not paraphrase or prepend extra text
-- Store the subagent result as `<pr-result>`
+- Store the result as `<implementation-result>`
+- If `<implementation-result>` is blocked or incomplete, STOP and report the implementation blocker
+
+### Delegate Branch Creation
+
+- Before delegating, send the exact task block below
+
+<task agent="general" command="/branch">
+Branch naming guidance: <ticket-summary>
+Additional context: <additional-context>
+</task>
+
+- Store the result as `<branch-result>`
+- If `<branch-result>` is blocked or incomplete, STOP and report the branch blocker
+- If `<branch-result>` says branching was skipped because the current branch already looks like a work branch, continue
+
+### Delegate Commit And Push
+
+- Before delegating, send the exact task block below
+
+<task agent="general" command="/commit-and-push">
+Ticket reference: <ticket-ref>
+Ticket summary: <ticket-summary>
+Additional context: <additional-context>
+</task>
+
+- Store the result as `<commit-result>`
+- If `<commit-result>` is blocked or incomplete, STOP and report the commit or push blocker
+- If `<commit-result>` says there was nothing to commit or push, continue to PR creation so already-committed branch work can still be shipped
+
+### Delegate PR Creation
+
+- Before delegating, send the exact task block below
+
+<task agent="general" command="/pr/create">
+Ticket reference: <ticket-ref>
+Ticket context: <ticket-context>
+Additional context: <additional-context>
+</task>
+
+- Store the result as `<pr-result>`
 - If `<pr-result>` is blocked or incomplete, STOP and report the PR blocker
 - Otherwise, continue and store the resulting PR URL as `<pr-url>`
 
 ## Additional Context
 
-Use `<additional-context>` to refine scope, sequencing, and tradeoffs while implementing `<ticket-context>`.
+Use `<additional-context>` to refine scope, sequencing, and tradeoffs across the delegated `/dev`, `/branch`, `/commit-and-push`, and `/pr/create` steps.
 
 ## Output
 
@@ -73,7 +101,8 @@ When the ticket work is complete, display:
 ```
 Implemented ticket: <ticket-summary>
 
+Implementation: <implementation-result>
+Branch: <branch-result>
+Commit and push: <commit-result>
 PR: <pr-url>
-Validation:
-<validation-results>
 ```

--- a/packages/opencode/.opencode/commands/todo.md
+++ b/packages/opencode/.opencode/commands/todo.md
@@ -40,7 +40,6 @@ $ARGUMENTS
 ### Delegate Planning
 
 <task agent="planner" command="/ticket/plan">
-
 Task: <task>
 Task context: <task-context>
 Additional context: <additional-context>
@@ -62,7 +61,6 @@ Additional context: <additional-context>
 - custom answers enabled so the user can provide specific plan changes
 - If the user requests changes, store that feedback as `<user-answer>`
 <task agent="planner" command="/ticket/plan">
-
 Task: <task>
 Task context: <task-context>
 Current plan: <plan>
@@ -78,7 +76,6 @@ Additional context: <additional-context>
 ### Delegate Implementation
 
 <task agent="general" command="/dev">
-
 Plan: <plan>
 Task: <task>
 Task context: <task-context>
@@ -91,7 +88,6 @@ Additional context: <additional-context>
 ### Delegate Commit
 
 <task agent="general" command="/commit">
-
 Task: <task>
 Additional context: <additional-context>
 </task>


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Tightens command workflow docs so PR creation, ticket delivery, and ship flows spell out the required ticket prompt behavior and the delegated execution path more clearly.

## Checklist
### Ticket handling
- [x] Require `/pr/create` to ask for ticket handling whenever no ticket guidance was provided
- [x] Prevent the workflow from defaulting to `skip` while interactive ticket input is available

### Delivery flow
- [x] Reframe `/ticket/dev` around delegated implementation, branching, commit-and-push, and PR creation steps
- [x] Keep `/ship` and `/todo` task blocks aligned with the updated command structure

### Generated output
- [x] Regenerate the mirrored OpenCode command docs to match the core command updates

### Validation
- [x] Verify that `/pr/create` pauses for ticket input before continuing when no ticket argument is supplied
- [x] Confirm that `/ticket/dev` reports implementation, branch, commit-and-push, and PR outcomes in sequence
- [x] Check that `/ship` and `/todo` still render clean task blocks without extra spacing