### PR TITLE
Add ask commands and ticket reply support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Use `@kompassdev/opencode` when you want Kompass workflows inside OpenCode.
 - install the plugin in your OpenCode config
 - optionally add one project override file to customize commands, agents, tools, skills, and defaults; `.opencode/kompass.jsonc` is preferred
 - bundled Kompass skills are registered automatically when the plugin loads, so users do not need to copy skill files manually
-- use commands like `/review`, `/pr/create`, or `/ticket/plan` inside OpenCode
+- use commands like `/ask`, `/review`, `/pr/create`, or `/ticket/plan` inside OpenCode
 - for CLI session debugging, use `opencode session list` to find a session id and `opencode export <sessionID>` to dump the raw session JSON
 
 ### Claude Code
@@ -80,6 +80,18 @@ Turns a request or ticket into a scoped implementation plan.
 Reviews branch or PR changes without editing files.
 
 ## Commands
+
+### `/ask`
+
+Answers questions about the current project or codebase.
+
+<details>
+
+**Usage:** `/ask <question>`
+
+Loads only the relevant repository context needed to answer a project or code question directly.
+
+</details>
 
 ### `/commit`
 
@@ -237,6 +249,18 @@ Creates a new GitHub issue with the provided description, generating a title and
 
 </details>
 
+### `/ticket/ask`
+
+Answers a question on a ticket and posts the response.
+
+<details>
+
+**Usage:** `/ticket/ask <ticket-reference> <question>`
+
+Loads the ticket plus all comments, answers the question using ticket and repository context, and posts the response back to the same ticket.
+
+</details>
+
 ### `/ticket/dev`
 
 Implements a ticket with planning and execution.
@@ -356,16 +380,17 @@ Create or update a GitHub issue with checklists.
 
 **Parameters:**
 
-- `title` (required): issue title
+- `title` (optional): issue title; required when creating a new issue or renaming one
 - `body` (optional): raw issue body override
 - `description` (optional): short issue description rendered above checklist sections
 - `labels` (optional): labels to apply when creating or updating the issue
 - `checklists` (optional): structured checklist sections rendered as markdown
 - `refUrl` (optional): issue URL to update instead of creating a new issue
+- `comments` (optional): issue comments to post without replacing the issue body
 
 **Why it helps:**
 
-- lets ticket flows create a new issue or update an existing one with one tool
+- lets ticket flows create a new issue, update an existing one, or post a ticket comment with one tool
 - avoids making the agent handcraft raw `gh` issue commands each time
 
 </details>

--- a/kompass.jsonc
+++ b/kompass.jsonc
@@ -11,6 +11,7 @@
 
   // Command config is now object-based so each entry can be toggled or customized.
   "commands": {
+    "ask": { "enabled": true },
     "commit": { "enabled": true },
     "commit-and-push": { "enabled": true },
     "dev": { "enabled": true },
@@ -23,6 +24,7 @@
     "ship": { "enabled": true },
     "rmslop": { "enabled": true },
     "todo": { "enabled": true },
+    "ticket/ask": { "enabled": true },
     "ticket/create": { "enabled": true },
     "ticket/dev": { "enabled": true },
     "ticket/plan": { "enabled": true },

--- a/packages/core/commands/ask.md
+++ b/packages/core/commands/ask.md
@@ -1,0 +1,44 @@
+## Goal
+
+Answer a question about the current project or codebase using the repository and available context.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- Treat `<arguments>` as `<question>`
+- If `<arguments>` includes explicit focus areas, files, or constraints, store them as `<additional-context>`
+- If `<question>` is empty, derive it from the conversation before continuing
+
+### Load Answering Context
+
+- Use the repository, conversation context, and relevant tools to gather only the code or project details needed to answer `<question>`
+- Store the important findings as `<answer-context>`
+- If `<question>` cannot be determined, STOP and report that the question is missing
+
+### Answer The Question
+
+- Answer `<question>` directly using `<answer-context>`
+- Prefer concrete, code-grounded answers over generic guidance
+- Include file references when they materially help the answer
+- Keep the response concise unless the question requires more detail
+
+## Additional Context
+
+- Use `<additional-context>` to prioritize the most relevant files, subsystems, or concerns
+- Ask only when the question cannot be determined from `<arguments>` and the conversation
+
+## Output
+
+If the question cannot be determined, display:
+```
+Unable to answer: missing question
+```
+
+When the answer is ready, display the answer directly.

--- a/packages/core/commands/index.ts
+++ b/packages/core/commands/index.ts
@@ -11,6 +11,11 @@ interface CommandDefinition {
 }
 
 export const commandDefinitions: Record<string, CommandDefinition> = {
+  ask: {
+    description: "Answer questions about the current project or code",
+    agent: "build",
+    templatePath: "commands/ask.md",
+  },
   branch: {
     description: "Create a feature branch from current changes",
     agent: "build",
@@ -77,6 +82,11 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
     description: "Work through a todo file task by task",
     agent: "navigator",
     templatePath: "commands/todo.md",
+  },
+  "ticket/ask": {
+    description: "Answer a question on a ticket and post the response",
+    agent: "build",
+    templatePath: "commands/ticket/ask.md",
   },
   "ticket/dev": {
     description: "Implement a ticket and create a PR",

--- a/packages/core/commands/ticket/ask.md
+++ b/packages/core/commands/ticket/ask.md
@@ -1,0 +1,55 @@
+## Goal
+
+Load a ticket and its discussion, answer the user's question, and post that answer back to the ticket.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` includes a ticket reference or URL, store it as `<ticket-url>`
+- Treat the remaining question or instruction as `<question>`
+- If `<arguments>` includes extra focus areas, caveats, or response constraints, store them as `<additional-context>`
+- If `<question>` is empty, derive it from the conversation before continuing
+
+### Load Ticket Context
+
+- Use `ticket_load` with `source: <ticket-url>` and `comments: true`
+- Store the result as `<ticket-context>`
+- If `<ticket-url>` is missing or `<ticket-context>` cannot be loaded, STOP and report that the ticket context is missing or invalid
+
+### Draft The Answer
+
+- Read the ticket body and comments in `<ticket-context>` to understand the request, history, and open questions
+- Answer `<question>` using the ticket discussion plus any necessary repository context
+- Store the response to post as `<ticket-answer>`
+
+### Sync Ticket
+
+- Use `ticket_sync` with:
+  - `refUrl: <ticket-url>`
+  - `comments: [<ticket-answer>]`
+- Store the returned ticket URL as `<ticket-url>`
+
+## Additional Context
+
+- Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
+- Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
+- Ask only when the ticket source or question cannot be determined reliably
+
+## Output
+
+If the ticket context or question cannot be determined, display:
+```
+Unable to answer ticket: missing ticket or question context
+```
+
+When the ticket answer is posted, display:
+```
+Answered ticket: <ticket-url>
+```

--- a/packages/core/kompass.jsonc
+++ b/packages/core/kompass.jsonc
@@ -11,6 +11,7 @@
 
   // Command config is now object-based so each entry can be toggled or customized.
   "commands": {
+    "ask": { "enabled": true },
     "commit": { "enabled": true },
     "commit-and-push": { "enabled": true },
     "dev": { "enabled": true },
@@ -23,6 +24,7 @@
     "ship": { "enabled": true },
     "rmslop": { "enabled": true },
     "todo": { "enabled": true },
+    "ticket/ask": { "enabled": true },
     "ticket/create": { "enabled": true },
     "ticket/dev": { "enabled": true },
     "ticket/plan": { "enabled": true },

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -20,6 +20,7 @@ export const DEFAULT_TOOL_NAMES = [
 ] as const;
 
 export const DEFAULT_COMMAND_NAMES = [
+  "ask",
   "branch",
   "commit",
   "commit-and-push",
@@ -33,6 +34,7 @@ export const DEFAULT_COMMAND_NAMES = [
   "ship",
   "rmslop",
   "todo",
+  "ticket/ask",
   "ticket/create",
   "ticket/dev",
   "ticket/plan",
@@ -98,6 +100,7 @@ export interface KompassConfig {
     validation?: string[];
   };
   commands?: {
+    ask?: CommandConfig;
     branch?: CommandConfig;
     commit?: CommandConfig;
     "commit-and-push"?: CommandConfig;
@@ -111,6 +114,7 @@ export interface KompassConfig {
     ship?: CommandConfig;
     rmslop?: CommandConfig;
     todo?: CommandConfig;
+    "ticket/ask"?: CommandConfig;
     "ticket/create"?: CommandConfig;
     "ticket/dev"?: CommandConfig;
     "ticket/plan"?: CommandConfig;

--- a/packages/core/test/ticket-sync.test.ts
+++ b/packages/core/test/ticket-sync.test.ts
@@ -71,6 +71,30 @@ describe("ticket_sync", () => {
     assert.match(executedCommand, /--add-label triage/);
     assert.match(executedCommand, /--body Updated body/);
   });
+
+  test("posts a comment to an existing issue without editing metadata", async () => {
+    const executedCommands: string[] = [];
+    const shell = createMockShell((command) => {
+      executedCommands.push(command);
+      return {
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      };
+    });
+
+    const tool = createTicketSyncTool(shell);
+    const output = await tool.execute({
+      refUrl: "https://github.com/acme/repo/issues/9",
+      comments: ["Here is the answer on the ticket."],
+    }, createToolContextForDirectory("/tmp/repo"));
+
+    const result = JSON.parse(output);
+    assert.equal(result.url, "https://github.com/acme/repo/issues/9");
+    assert.equal(executedCommands.length, 1);
+    assert.match(executedCommands[0]!, /gh issue comment/);
+    assert.match(executedCommands[0]!, /--body Here is the answer on the ticket\./);
+  });
 });
 
 function createMockShell(

--- a/packages/core/tools/ticket-sync.ts
+++ b/packages/core/tools/ticket-sync.ts
@@ -6,7 +6,7 @@ import {
 } from "./shared.ts";
 
 type TicketSyncArgs = {
-  title: string;
+  title?: string;
   body?: string;
   description?: string;
   labels?: string[];
@@ -18,6 +18,7 @@ type TicketSyncArgs = {
     }>;
   }>;
   refUrl?: string;
+  comments?: string[];
 };
 
 function renderTicketBody(args: TicketSyncArgs) {
@@ -44,11 +45,7 @@ function renderTicketBody(args: TicketSyncArgs) {
   }
 
   const body = sections.join("\n\n").trim();
-  if (!body) {
-    throw new Error("ticket_sync requires body, description, or checklist content");
-  }
-
-  return body;
+  return body || undefined;
 }
 
 function collectLabels(labels?: string[]): string[] {
@@ -57,11 +54,32 @@ function collectLabels(labels?: string[]): string[] {
     .map((label) => label.trim());
 }
 
+function hasMetadataUpdate(args: TicketSyncArgs, body?: string) {
+  return Boolean(args.title?.trim() || body || collectLabels(args.labels).length > 0);
+}
+
+async function postIssueComment($: Shell, worktree: string, issueRef: string, body: string) {
+  const proc = await $`gh issue comment ${issueRef} --body ${body}`
+    .cwd(worktree)
+    .quiet()
+    .nothrow();
+
+  if (proc.exitCode !== 0) {
+    throw new Error(proc.stderr.toString() || "Failed to post issue comment");
+  }
+}
+
+function collectComments(comments?: string[]): string[] {
+  return (comments ?? [])
+    .filter((comment) => comment.trim())
+    .map((comment) => comment.trim());
+}
+
 export function createTicketSyncTool($: Shell) {
   return {
     description: "Create or update a GitHub issue",
     args: {
-      title: { type: "string", description: "Issue title" },
+      title: { type: "string", optional: true, description: "Issue title" },
       body: {
         type: "string",
         optional: true,
@@ -87,20 +105,40 @@ export function createTicketSyncTool($: Shell) {
         optional: true,
         description: "Optional issue URL to update instead of creating a new issue",
       },
+      comments: {
+        type: "string[]",
+        optional: true,
+        description: "Optional issue comments to post",
+      },
     },
     async execute(args: TicketSyncArgs, ctx: ToolExecutionContext) {
       const body = renderTicketBody(args);
+      const labels = collectLabels(args.labels);
+      const comments = collectComments(args.comments);
 
       if (args.refUrl) {
-        const labels = collectLabels(args.labels);
-        const labelArgs = labels.flatMap((label) => ["--add-label", label]);
-        const proc = await $`gh issue edit ${args.refUrl} --title ${args.title} --body ${body} ${labelArgs}`
-          .cwd(ctx.worktree)
-          .quiet()
-          .nothrow();
+        if (!hasMetadataUpdate(args, body) && comments.length === 0) {
+          throw new Error("ticket_sync requires title, body, description, checklist content, labels, or comments when updating an issue");
+        }
 
-        if (proc.exitCode !== 0) {
-          throw new Error(proc.stderr.toString() || "Failed to update issue");
+        if (hasMetadataUpdate(args, body)) {
+          const editArgs = [
+            ...(args.title?.trim() ? ["--title", args.title.trim()] : []),
+            ...(body ? ["--body", body] : []),
+            ...labels.flatMap((label) => ["--add-label", label]),
+          ];
+          const proc = await $`gh issue edit ${args.refUrl} ${editArgs}`
+            .cwd(ctx.worktree)
+            .quiet()
+            .nothrow();
+
+          if (proc.exitCode !== 0) {
+            throw new Error(proc.stderr.toString() || "Failed to update issue");
+          }
+        }
+
+        for (const comment of comments) {
+          await postIssueComment($, ctx.worktree, args.refUrl, comment);
         }
 
         return stringifyJson({
@@ -108,9 +146,16 @@ export function createTicketSyncTool($: Shell) {
         });
       }
 
-      const labels = collectLabels(args.labels);
+      if (!args.title?.trim()) {
+        throw new Error("ticket_sync requires title when creating an issue");
+      }
+
+      if (!body) {
+        throw new Error("ticket_sync requires body, description, or checklist content when creating an issue");
+      }
+
       const labelArgs = labels.flatMap((label) => ["--label", label]);
-      const proc = await $`gh issue create --title ${args.title} --body ${body} ${labelArgs}`
+      const proc = await $`gh issue create --title ${args.title.trim()} --body ${body} ${labelArgs}`
         .cwd(ctx.worktree)
         .quiet()
         .nothrow();
@@ -119,8 +164,14 @@ export function createTicketSyncTool($: Shell) {
         throw new Error(proc.stderr.toString() || "Failed to create issue");
       }
 
+      const url = proc.text().trim();
+
+      for (const comment of comments) {
+        await postIssueComment($, ctx.worktree, url, comment);
+      }
+
       return stringifyJson({
-        url: proc.text().trim(),
+        url,
       });
     },
   } satisfies ToolDefinition<TicketSyncArgs>;

--- a/packages/opencode/.opencode/commands/ask.md
+++ b/packages/opencode/.opencode/commands/ask.md
@@ -1,0 +1,49 @@
+---
+description: Answer questions about the current project or code
+agent: build
+---
+
+## Goal
+
+Answer a question about the current project or codebase using the repository and available context.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- Treat `<arguments>` as `<question>`
+- If `<arguments>` includes explicit focus areas, files, or constraints, store them as `<additional-context>`
+- If `<question>` is empty, derive it from the conversation before continuing
+
+### Load Answering Context
+
+- Use the repository, conversation context, and relevant tools to gather only the code or project details needed to answer `<question>`
+- Store the important findings as `<answer-context>`
+- If `<question>` cannot be determined, STOP and report that the question is missing
+
+### Answer The Question
+
+- Answer `<question>` directly using `<answer-context>`
+- Prefer concrete, code-grounded answers over generic guidance
+- Include file references when they materially help the answer
+- Keep the response concise unless the question requires more detail
+
+## Additional Context
+
+- Use `<additional-context>` to prioritize the most relevant files, subsystems, or concerns
+- Ask only when the question cannot be determined from `<arguments>` and the conversation
+
+## Output
+
+If the question cannot be determined, display:
+```
+Unable to answer: missing question
+```
+
+When the answer is ready, display the answer directly.

--- a/packages/opencode/.opencode/commands/ticket/ask.md
+++ b/packages/opencode/.opencode/commands/ticket/ask.md
@@ -1,0 +1,60 @@
+---
+description: Answer a question on a ticket and post the response
+agent: build
+---
+
+## Goal
+
+Load a ticket and its discussion, answer the user's question, and post that answer back to the ticket.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` includes a ticket reference or URL, store it as `<ticket-url>`
+- Treat the remaining question or instruction as `<question>`
+- If `<arguments>` includes extra focus areas, caveats, or response constraints, store them as `<additional-context>`
+- If `<question>` is empty, derive it from the conversation before continuing
+
+### Load Ticket Context
+
+- Use `kompass_ticket_load` with `source: <ticket-url>` and `comments: true`
+- Store the result as `<ticket-context>`
+- If `<ticket-url>` is missing or `<ticket-context>` cannot be loaded, STOP and report that the ticket context is missing or invalid
+
+### Draft The Answer
+
+- Read the ticket body and comments in `<ticket-context>` to understand the request, history, and open questions
+- Answer `<question>` using the ticket discussion plus any necessary repository context
+- Store the response to post as `<ticket-answer>`
+
+### Sync Ticket
+
+- Use `kompass_ticket_sync` with:
+  - `refUrl: <ticket-url>`
+  - `comments: [<ticket-answer>]`
+- Store the returned ticket URL as `<ticket-url>`
+
+## Additional Context
+
+- Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
+- Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
+- Ask only when the ticket source or question cannot be determined reliably
+
+## Output
+
+If the ticket context or question cannot be determined, display:
+```
+Unable to answer ticket: missing ticket or question context
+```
+
+When the ticket answer is posted, display:
+```
+Answered ticket: <ticket-url>
+```

--- a/packages/opencode/.opencode/kompass.jsonc
+++ b/packages/opencode/.opencode/kompass.jsonc
@@ -7,6 +7,9 @@
     ]
   },
   "commands": {
+    "ask": {
+      "enabled": true
+    },
     "branch": {
       "enabled": true
     },
@@ -44,6 +47,9 @@
       "enabled": true
     },
     "todo": {
+      "enabled": true
+    },
+    "ticket/ask": {
       "enabled": true
     },
     "ticket/create": {

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -56,7 +56,7 @@ Use `@kompassdev/opencode` when you want Kompass workflows inside OpenCode.
 - install the plugin in your OpenCode config
 - optionally add one project override file to customize commands, agents, tools, skills, and defaults; `.opencode/kompass.jsonc` is preferred
 - bundled Kompass skills are registered automatically when the plugin loads, so users do not need to copy skill files manually
-- use commands like `/review`, `/pr/create`, or `/ticket/plan` inside OpenCode
+- use commands like `/ask`, `/review`, `/pr/create`, or `/ticket/plan` inside OpenCode
 - for CLI session debugging, use `opencode session list` to find a session id and `opencode export <sessionID>` to dump the raw session JSON
 
 ### Claude Code
@@ -80,6 +80,18 @@ Turns a request or ticket into a scoped implementation plan.
 Reviews branch or PR changes without editing files.
 
 ## Commands
+
+### `/ask`
+
+Answers questions about the current project or codebase.
+
+<details>
+
+**Usage:** `/ask <question>`
+
+Loads only the relevant repository context needed to answer a project or code question directly.
+
+</details>
 
 ### `/commit`
 
@@ -237,6 +249,18 @@ Creates a new GitHub issue with the provided description, generating a title and
 
 </details>
 
+### `/ticket/ask`
+
+Answers a question on a ticket and posts the response.
+
+<details>
+
+**Usage:** `/ticket/ask <ticket-reference> <question>`
+
+Loads the ticket plus all comments, answers the question using ticket and repository context, and posts the response back to the same ticket.
+
+</details>
+
 ### `/ticket/dev`
 
 Implements a ticket with planning and execution.
@@ -356,16 +380,17 @@ Create or update a GitHub issue with checklists.
 
 **Parameters:**
 
-- `title` (required): issue title
+- `title` (optional): issue title; required when creating a new issue or renaming one
 - `body` (optional): raw issue body override
 - `description` (optional): short issue description rendered above checklist sections
 - `labels` (optional): labels to apply when creating or updating the issue
 - `checklists` (optional): structured checklist sections rendered as markdown
 - `refUrl` (optional): issue URL to update instead of creating a new issue
+- `comments` (optional): issue comments to post without replacing the issue body
 
 **Why it helps:**
 
-- lets ticket flows create a new issue or update an existing one with one tool
+- lets ticket flows create a new issue, update an existing one, or post a ticket comment with one tool
 - avoids making the agent handcraft raw `gh` issue commands each time
 
 </details>

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -289,7 +289,7 @@ const opencodeToolCreators = {
     return tool({
       description: definition.description,
       args: {
-        title: tool.schema.string().describe("Issue title"),
+        title: tool.schema.string().describe("Issue title").optional(),
         body: tool.schema.string().describe("Issue body override").optional(),
         description: tool.schema.string().describe("Issue description rendered above checklist sections").optional(),
         labels: tool.schema.array(tool.schema.string()).describe("Labels to apply to the issue").optional(),
@@ -301,6 +301,7 @@ const opencodeToolCreators = {
           })).describe("Checklist items"),
         })).describe("Checklist sections rendered as markdown").optional(),
         refUrl: tool.schema.string().describe("Optional issue URL to update").optional(),
+        comments: tool.schema.array(tool.schema.string()).describe("Optional issue comments to post").optional(),
       },
       execute: (args, context) => definition.execute(args, context),
     });

--- a/packages/opencode/kompass.jsonc
+++ b/packages/opencode/kompass.jsonc
@@ -11,6 +11,7 @@
 
   // Command config is now object-based so each entry can be toggled or customized.
   "commands": {
+    "ask": { "enabled": true },
     "commit": { "enabled": true },
     "commit-and-push": { "enabled": true },
     "dev": { "enabled": true },
@@ -23,6 +24,7 @@
     "ship": { "enabled": true },
     "rmslop": { "enabled": true },
     "todo": { "enabled": true },
+    "ticket/ask": { "enabled": true },
     "ticket/create": { "enabled": true },
     "ticket/dev": { "enabled": true },
     "ticket/plan": { "enabled": true },

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -27,12 +27,14 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       const expectedCommands = [
+        "ask",
         "branch",
         "reload",
         "pr/create",
         "pr/review",
         "pr/fix",
         "ship",
+        "ticket/ask",
         "ticket/create",
         "ticket/plan",
         "ticket/dev",
@@ -57,6 +59,8 @@ describe("applyCommandsConfig", () => {
       assert.equal(cfg.command!["pr/create"]?.agent, "build");
       assert.equal(cfg.command!["ticket/create"]?.agent, "build");
       assert.equal(cfg.command!["ticket/plan"]?.agent, "planner");
+      assert.equal(cfg.command!["ask"]?.agent, "build");
+      assert.equal(cfg.command!["ticket/ask"]?.agent, "build");
       assert.equal(cfg.command!["dev"]?.agent, "build");
       assert.equal(cfg.command!["ship"]?.agent, "navigator");
       assert.equal(cfg.command!["todo"]?.agent, "navigator");
@@ -410,7 +414,9 @@ describe("applyCommandsConfig", () => {
       assert.ok(cfg.command!["dev"]?.template);
       assert.ok(cfg.command!["pr/create"]?.template);
       assert.ok(cfg.command!["ticket/create"]?.template);
+      assert.ok(cfg.command!["ask"]?.template);
       assert.ok(cfg.command!["pr/review"]?.template);
+      assert.ok(cfg.command!["ticket/ask"]?.template);
       assert.ok(cfg.command!["ticket/plan"]?.template);
       assert.ok(cfg.command!["pr/fix"]?.template);
       assert.ok(cfg.command!["ship"]?.template);

--- a/packages/opencode/test/tool-registration.test.ts
+++ b/packages/opencode/test/tool-registration.test.ts
@@ -139,4 +139,14 @@ describe("createOpenCodeTools", () => {
       await rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  test("exposes comments on ticket_sync and makes title optional", async () => {
+    const tools = await createOpenCodeTools((() => {
+      throw new Error("not implemented");
+    }) as never, createMockClient(), process.cwd());
+
+    const ticketSyncArgs = (tools.kompass_ticket_sync as any).args;
+    assert.ok(ticketSyncArgs.comments);
+    assert.equal(ticketSyncArgs.title.isOptional(), true);
+  });
 });


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Adds direct project Q&A commands and extends ticket syncing so ticket-answer flows can post comments without rewriting issue metadata.

## Checklist
### Question workflows
- [x] Add `/ask` as a first-class command and enable it in shared configs
- [x] Document the new ask workflow across workspace and OpenCode docs

### Ticket replies
- [x] Add `/ticket/ask` command flow for answering ticket questions and posting the response
- [x] Extend `ticket_sync` to support comment-only updates and optional titles for existing issues

### Integration coverage
- [x] Register the new commands in command resolution and OpenCode command config
- [x] Add tests for ticket comments and updated OpenCode tool exposure

### Validation
- [x] Verify `/ask <question>` resolves and answers using repository context
- [x] Confirm `/ticket/ask <ticket-reference> <question>` posts a reply comment without replacing issue content
- [x] Check that OpenCode exposes `ticket_sync.comments` and accepts optional `title`