### PR TITLE
Add self-assignee support to ticket and PR sync

### DIFF
--- a/packages/core/commands/pr/create.md
+++ b/packages/core/commands/pr/create.md
@@ -76,6 +76,7 @@ $ARGUMENTS
 When `<ticket-mode>` is `auto`, create the ticket before creating the PR:
 <%~ include("@changes-summary") %>
 - Use `ticket_sync` with `refUrl` unset
+- Set `assignees` to `[@me]` so the created ticket is assigned to yourself as the author
 - Store the created issue reference or URL as `<ticket-url>`
 
 Otherwise:
@@ -99,6 +100,7 @@ Use `pr_sync` to create the pull request:
 - Generate a concise title (max 70 chars) summarizing the change and store it as `<pr-title>`
 - Generate a short description that briefly describes the intent and scope
 - Pass `<current-branch>` as `head` when it is available so PR creation does not depend on local upstream inference
+- Set `assignees` to `[@me]` so the created PR is assigned to yourself as the author
 - Generate a compact checklist that mirrors the same human-facing structure used for the ticket summary:
   - group delivered work into 2-4 functional or outcome-focused sections
   - use concise section names instead of generic labels like `Changes`

--- a/packages/core/commands/ticket/create.md
+++ b/packages/core/commands/ticket/create.md
@@ -32,6 +32,7 @@ $ARGUMENTS
 
 Use `ticket_sync` with `refUrl` unset to create the ticket:
 <%~ include("@changes-summary") %>
+- Set `assignees` to `[@me]` so the created ticket is assigned to yourself as the author
 - Store the generated title as `<ticket-title>`
 - Store the created issue URL as `<ticket-url>`
 

--- a/packages/core/test/pr-sync.test.ts
+++ b/packages/core/test/pr-sync.test.ts
@@ -6,7 +6,7 @@ import type { Shell, ShellPromise } from "../tools/shared.ts";
 import { createPrSyncTool } from "../tools/pr-sync.ts";
 
 describe("pr_sync", () => {
-  test("creates a PR with explicit head branch", async () => {
+  test("creates a PR with explicit head branch and assignees", async () => {
     const executedCommands: string[] = [];
     const shell = createMockShell(executedCommands, [
       {
@@ -21,6 +21,7 @@ describe("pr_sync", () => {
       body: "Uses explicit head branch when creating PRs.",
       base: "main",
       head: "feature/pr-head",
+      assignees: ["octocat", "hubot"],
     }, createToolContextForDirectory("/tmp/repo"));
 
     const result = JSON.parse(output);
@@ -28,6 +29,8 @@ describe("pr_sync", () => {
     assert.equal(result.action, "created");
     assert.match(executedCommands[0], /--base main/);
     assert.match(executedCommands[0], /--head feature\/pr-head/);
+    assert.match(executedCommands[0], /--assignee octocat/);
+    assert.match(executedCommands[0], /--assignee hubot/);
   });
 
   test("creates a PR without head when head is omitted", async () => {
@@ -97,6 +100,7 @@ describe("pr_sync", () => {
     const output = await tool.execute({
       title: "Tighten review automation",
       body: "Updated body",
+      assignees: ["octocat"],
       refUrl: "https://github.com/acme/repo/pull/9",
       review: { approve: true },
     }, createToolContextForDirectory("/tmp/repo"));
@@ -105,6 +109,7 @@ describe("pr_sync", () => {
     assert.equal(result.action, "updated_and_approved");
     assert.match(executedCommands[1], /--title Tighten review automation/);
     assert.match(executedCommands[1], /--body Updated body/);
+    assert.match(executedCommands[1], /--add-assignee octocat/);
   });
 
   test("submits structured review comments through pr_sync", async () => {

--- a/packages/core/test/ticket-sync.test.ts
+++ b/packages/core/test/ticket-sync.test.ts
@@ -6,7 +6,7 @@ import type { Shell, ShellPromise } from "../tools/shared.ts";
 import { createTicketSyncTool } from "../tools/ticket-sync.ts";
 
 describe("ticket_sync", () => {
-  test("renders description, checklists, and labels when creating an issue", async () => {
+  test("renders description, checklists, labels, and assignees when creating an issue", async () => {
     let executedCommand = "";
     const shell = createMockShell((command) => {
       executedCommand = command;
@@ -22,6 +22,7 @@ describe("ticket_sync", () => {
       title: "Add plan sync improvements",
       description: "Capture planning output with clearer ticket formatting.",
       labels: ["planning", "tickets"],
+      assignees: ["octocat", "hubot"],
       checklists: [
         {
           name: "Requirement",
@@ -39,6 +40,8 @@ describe("ticket_sync", () => {
     assert.match(executedCommand, /gh issue create/);
     assert.match(executedCommand, /--label planning/);
     assert.match(executedCommand, /--label tickets/);
+    assert.match(executedCommand, /--assignee octocat/);
+    assert.match(executedCommand, /--assignee hubot/);
     assert.match(executedCommand, /Capture planning output with clearer ticket formatting\./);
     assert.match(executedCommand, /### Requirement/);
     assert.match(executedCommand, /- \[ \] Improve the ticket plan prompt/);
@@ -46,7 +49,7 @@ describe("ticket_sync", () => {
     assert.match(executedCommand, /- \[x\] Confirm checklist sections render correctly/);
   });
 
-  test("updates an existing issue with add-label flags", async () => {
+  test("updates an existing issue with add-label and add-assignee flags", async () => {
     let executedCommand = "";
     const shell = createMockShell((command) => {
       executedCommand = command;
@@ -62,6 +65,7 @@ describe("ticket_sync", () => {
       title: "Refresh plan",
       body: "Updated body",
       labels: ["triage"],
+      assignees: ["octocat"],
       refUrl: "https://github.com/acme/repo/issues/9",
     }, createToolContextForDirectory("/tmp/repo"));
 
@@ -69,6 +73,7 @@ describe("ticket_sync", () => {
     assert.equal(result.url, "https://github.com/acme/repo/issues/9");
     assert.match(executedCommand, /gh issue edit/);
     assert.match(executedCommand, /--add-label triage/);
+    assert.match(executedCommand, /--add-assignee octocat/);
     assert.match(executedCommand, /--body Updated body/);
   });
 

--- a/packages/core/tools/pr-sync.ts
+++ b/packages/core/tools/pr-sync.ts
@@ -35,6 +35,7 @@ type PrSyncArgs = {
   description?: string;
   base?: string;
   head?: string;
+  assignees?: string[];
   checklists?: Array<{
     name: string;
     items: Array<{
@@ -78,7 +79,18 @@ function renderPrBody(args: PrSyncArgs) {
 }
 
 function hasMetadataUpdate(args: PrSyncArgs, body?: string) {
-  return Boolean(args.title?.trim() || body || args.base?.trim());
+  return Boolean(
+    args.title?.trim() ||
+      body ||
+      args.base?.trim() ||
+      collectAssignees(args.assignees).length > 0,
+  );
+}
+
+function collectAssignees(assignees?: string[]): string[] {
+  return (assignees ?? [])
+    .filter((assignee) => assignee.trim())
+    .map((assignee) => assignee.trim());
 }
 
 function requiresExistingPullRequest(args: PrSyncArgs, review?: ReviewInput) {
@@ -300,7 +312,7 @@ async function updatePullRequest(
   $: Shell,
   worktree: string,
   refUrl: string,
-  args: { title?: string; body?: string; base?: string },
+  args: { title?: string; body?: string; base?: string; assignees?: string[] },
 ) {
   const updateArgs: string[] = [];
   if (args.title?.trim()) {
@@ -311,6 +323,9 @@ async function updatePullRequest(
   }
   if (args.base?.trim()) {
     updateArgs.push("--base", args.base.trim());
+  }
+  for (const assignee of collectAssignees(args.assignees)) {
+    updateArgs.push("--add-assignee", assignee);
   }
 
   if (updateArgs.length === 0) {
@@ -356,6 +371,11 @@ export function createPrSyncTool($: Shell) {
         type: "string",
         optional: true,
         description: "Base branch to merge into (defaults to repo default branch)",
+      },
+      assignees: {
+        type: "string[]",
+        optional: true,
+        description: "Assignees to apply to the PR",
       },
       checklists: {
         type: "json",
@@ -420,6 +440,9 @@ export function createPrSyncTool($: Shell) {
         if (headBranch) {
           createArgs.push("--head", headBranch);
         }
+        for (const assignee of collectAssignees(args.assignees)) {
+          createArgs.push("--assignee", assignee);
+        }
         if (args.draft) {
           createArgs.push("--draft");
         }
@@ -454,6 +477,7 @@ export function createPrSyncTool($: Shell) {
           title: args.title,
           body,
           base: args.base,
+          assignees: args.assignees,
         });
         if (updated) {
           actions.push("updated");

--- a/packages/core/tools/ticket-sync.ts
+++ b/packages/core/tools/ticket-sync.ts
@@ -10,6 +10,7 @@ type TicketSyncArgs = {
   body?: string;
   description?: string;
   labels?: string[];
+  assignees?: string[];
   checklists?: Array<{
     name: string;
     items: Array<{
@@ -54,8 +55,19 @@ function collectLabels(labels?: string[]): string[] {
     .map((label) => label.trim());
 }
 
+function collectAssignees(assignees?: string[]): string[] {
+  return (assignees ?? [])
+    .filter((assignee) => assignee.trim())
+    .map((assignee) => assignee.trim());
+}
+
 function hasMetadataUpdate(args: TicketSyncArgs, body?: string) {
-  return Boolean(args.title?.trim() || body || collectLabels(args.labels).length > 0);
+  return Boolean(
+    args.title?.trim() ||
+      body ||
+      collectLabels(args.labels).length > 0 ||
+      collectAssignees(args.assignees).length > 0,
+  );
 }
 
 async function postIssueComment($: Shell, worktree: string, issueRef: string, body: string) {
@@ -95,6 +107,11 @@ export function createTicketSyncTool($: Shell) {
         optional: true,
         description: "Labels to apply to the issue",
       },
+      assignees: {
+        type: "string[]",
+        optional: true,
+        description: "Assignees to apply to the issue",
+      },
       checklists: {
         type: "json",
         optional: true,
@@ -114,6 +131,7 @@ export function createTicketSyncTool($: Shell) {
     async execute(args: TicketSyncArgs, ctx: ToolExecutionContext) {
       const body = renderTicketBody(args);
       const labels = collectLabels(args.labels);
+      const assignees = collectAssignees(args.assignees);
       const comments = collectComments(args.comments);
 
       if (args.refUrl) {
@@ -126,6 +144,7 @@ export function createTicketSyncTool($: Shell) {
             ...(args.title?.trim() ? ["--title", args.title.trim()] : []),
             ...(body ? ["--body", body] : []),
             ...labels.flatMap((label) => ["--add-label", label]),
+            ...assignees.flatMap((assignee) => ["--add-assignee", assignee]),
           ];
           const proc = await $`gh issue edit ${args.refUrl} ${editArgs}`
             .cwd(ctx.worktree)
@@ -155,7 +174,8 @@ export function createTicketSyncTool($: Shell) {
       }
 
       const labelArgs = labels.flatMap((label) => ["--label", label]);
-      const proc = await $`gh issue create --title ${args.title.trim()} --body ${body} ${labelArgs}`
+      const assigneeArgs = assignees.flatMap((assignee) => ["--assignee", assignee]);
+      const proc = await $`gh issue create --title ${args.title.trim()} --body ${body} ${labelArgs} ${assigneeArgs}`
         .cwd(ctx.worktree)
         .quiet()
         .nothrow();

--- a/packages/opencode/.opencode/commands/pr/create.md
+++ b/packages/opencode/.opencode/commands/pr/create.md
@@ -112,6 +112,7 @@ When `<ticket-mode>` is `auto`, create the ticket before creating the PR:
 - Do not use execution-status notes such as `Validation not run in this session` as checklist items
 - If `kompass_changes_load` reports uncommitted work, make that clear in the ticket wording
 - Use `kompass_ticket_sync` with `refUrl` unset
+- Set `assignees` to `[@me]` so the created ticket is assigned to yourself as the author
 - Store the created issue reference or URL as `<ticket-url>`
 
 Otherwise:
@@ -135,6 +136,7 @@ Use `kompass_pr_sync` to create the pull request:
 - Generate a concise title (max 70 chars) summarizing the change and store it as `<pr-title>`
 - Generate a short description that briefly describes the intent and scope
 - Pass `<current-branch>` as `head` when it is available so PR creation does not depend on local upstream inference
+- Set `assignees` to `[@me]` so the created PR is assigned to yourself as the author
 - Generate a compact checklist that mirrors the same human-facing structure used for the ticket summary:
   - group delivered work into 2-4 functional or outcome-focused sections
   - use concise section names instead of generic labels like `Changes`

--- a/packages/opencode/.opencode/commands/ticket/create.md
+++ b/packages/opencode/.opencode/commands/ticket/create.md
@@ -67,6 +67,7 @@ Use `kompass_ticket_sync` with `refUrl` unset to create the ticket:
 - Do not restate the full diff
 - Do not use execution-status notes such as `Validation not run in this session` as checklist items
 - If `kompass_changes_load` reports uncommitted work, make that clear in the ticket wording
+- Set `assignees` to `[@me]` so the created ticket is assigned to yourself as the author
 - Store the generated title as `<ticket-title>`
 - Store the created issue URL as `<ticket-url>`
 

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -250,6 +250,7 @@ const opencodeToolCreators = {
         description: tool.schema.string().describe("Short PR description rendered above checklist sections").optional(),
         base: tool.schema.string().describe("Base branch to merge into").optional(),
         head: tool.schema.string().describe("Head branch to use when creating a PR").optional(),
+        assignees: tool.schema.array(tool.schema.string()).describe("Assignees to apply to the PR").optional(),
         checklists: tool.schema.array(tool.schema.object({
           name: tool.schema.string().describe("Checklist section name"),
           items: tool.schema.array(tool.schema.object({
@@ -293,6 +294,7 @@ const opencodeToolCreators = {
         body: tool.schema.string().describe("Issue body override").optional(),
         description: tool.schema.string().describe("Issue description rendered above checklist sections").optional(),
         labels: tool.schema.array(tool.schema.string()).describe("Labels to apply to the issue").optional(),
+        assignees: tool.schema.array(tool.schema.string()).describe("Assignees to apply to the issue").optional(),
         checklists: tool.schema.array(tool.schema.object({
           name: tool.schema.string().describe("Checklist section name"),
           items: tool.schema.array(tool.schema.object({

--- a/packages/opencode/test/tool-registration.test.ts
+++ b/packages/opencode/test/tool-registration.test.ts
@@ -140,12 +140,15 @@ describe("createOpenCodeTools", () => {
     }
   });
 
-  test("exposes comments on ticket_sync and makes title optional", async () => {
+  test("exposes ticket assignees and comments, and PR assignees", async () => {
     const tools = await createOpenCodeTools((() => {
       throw new Error("not implemented");
     }) as never, createMockClient(), process.cwd());
 
+    const prSyncArgs = (tools.kompass_pr_sync as any).args;
     const ticketSyncArgs = (tools.kompass_ticket_sync as any).args;
+    assert.ok(prSyncArgs.assignees);
+    assert.ok(ticketSyncArgs.assignees);
     assert.ok(ticketSyncArgs.comments);
     assert.equal(ticketSyncArgs.title.isOptional(), true);
   });


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Assign workflow-created tickets and pull requests to the current author so generated GitHub work stays owned without extra manual steps.

## Checklist
### Author ownership
- [x] Add assignee support to ticket and PR sync inputs and CLI flags
- [x] Apply self-assignment when creating or updating GitHub tickets and pull requests

### Workflow guidance
- [x] Update command docs to require assigning generated tickets and PRs to the author
- [x] Expose the new assignee arguments through the OpenCode tool registration layer

### Coverage
- [x] Extend sync tool and registration tests for assignee handling

### Validation
- [x] Verify that creating a ticket assigns it to the current user
- [x] Verify that creating a pull request assigns it to the current user
- [x] Confirm that updating existing tickets and pull requests adds assignees correctly