### PR TITLE
docs: standardize terminal command completion output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ packages/opencode/.opencode/ # Generated OpenCode output for review
 - Use `## Additional Context` for instructions about how optional guidance, related tickets, focus areas, or other stored context should influence analysis and output
 - Use `## Output` to define the exact user-facing response shape, including placeholders for generated values
 - Make success, blocked, and no-op outcomes explicit in `## Output` or the surrounding workflow so navigator-led flows report deterministic end states
+- For terminal command outcomes, prefer an explicit final line inside the output block: `No additional steps are required.`
+- For one-off commands that do not orchestrate follow-up work, make every success, blocked, or no-op output explicitly terminal with that final line
 - Command-specific extra sections are fine, but they should support this core structure rather than replace it
 
 Example command structure:
@@ -117,6 +119,7 @@ Constraints: <additional-context>
 ## Output
 
 - Define the exact success, blocked, and no-op response shapes
+- For terminal outcomes, end the output block with `No additional steps are required.`
 ```
 
 Example delegation rule:

--- a/packages/core/commands/ask.md
+++ b/packages/core/commands/ask.md
@@ -39,6 +39,13 @@ $ARGUMENTS
 If the question cannot be determined, display:
 ```
 Unable to answer: missing question
+
+No additional steps are required.
 ```
 
-When the answer is ready, display the answer directly.
+When the answer is ready, display:
+```
+<answer>
+
+No additional steps are required.
+```

--- a/packages/core/commands/branch.md
+++ b/packages/core/commands/branch.md
@@ -45,11 +45,15 @@ Use `<branch-context>` to steer the branch category and slug while keeping the f
 If there is nothing to branch from, display:
 ```
 Nothing to branch from
+
+No additional steps are required.
 ```
 
 If branching is skipped because the current branch already looks like a work branch, display:
 ```
 Already on work branch: <current-branch>
+
+No additional steps are required.
 ```
 
 When the branch is created, display:
@@ -57,4 +61,6 @@ When the branch is created, display:
 Created branch: <new-branch>
 
 From: <current-branch>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/commit-and-push.md
+++ b/packages/core/commands/commit-and-push.md
@@ -45,6 +45,8 @@ Consider `<additional-context>` when analyzing changes and writing the commit me
 If there is nothing to commit, display:
 ```
 Nothing to commit or push
+
+No additional steps are required.
 ```
 
 When complete, display:
@@ -54,4 +56,6 @@ Created commit `<hash>`:
 <commit-message>
 
 Pushed to <push-target>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/commit.md
+++ b/packages/core/commands/commit.md
@@ -38,6 +38,8 @@ Consider `<additional-context>` when analyzing changes and writing the commit me
 If there is nothing to commit, display:
 ```
 Nothing to commit
+
+No additional steps are required.
 ```
 
 When the commit is created, display:
@@ -45,4 +47,6 @@ When the commit is created, display:
 Created commit `<hash>`:
 
 <commit-message>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/dev.md
+++ b/packages/core/commands/dev.md
@@ -59,5 +59,7 @@ Implementation ready: <request-summary>
 Validation:
 <validation-results>
 
-Next: create a PR for <branch>
+Ready for PR creation on <branch>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/learn.md
+++ b/packages/core/commands/learn.md
@@ -72,4 +72,6 @@ Documented learnings for <focus-summary>
 
 Files updated:
 <file-update-lines>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/pr/create.md
+++ b/packages/core/commands/pr/create.md
@@ -131,6 +131,8 @@ Consider `<additional-context>` when analyzing changes and writing the PR descri
 If PR creation stops because there is nothing to include, display:
 ```
 Nothing to include in a PR
+
+No additional steps are required.
 ```
 
 When a new PR is created, display:
@@ -140,6 +142,10 @@ Created PR: <pr-title>
 URL: <pr-url>
 Branch: <current-branch> → <resolved-base>
 Ticket: <ticket-url>
+<push-status>
+<pushed-line>
+
+No additional steps are required.
 ```
 
 If a PR already exists for the branch, display:
@@ -149,14 +155,8 @@ PR already exists
 URL: <pr-url>
 Branch: <current-branch> → <resolved-base>
 Ticket: <ticket-url>
-```
-
-After the ticket line, always include one additional line reporting push status:
-```
 <push-status>
-```
-
-If a push happened during this run, include one more line:
-```
 <pushed-line>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -123,10 +123,11 @@ When fixes are complete, display exactly this final completion summary and stop.
 ```
 PR fix complete for #<pr-context.pr.number>
 
-- Status: complete, no additional steps needed
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>
 - Validation passing: <validation-passing>
 - Validation details: <validation-results>
 - Pushed: <pushed>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/pr/review.md
+++ b/packages/core/commands/pr/review.md
@@ -55,11 +55,12 @@ Before publishing, derive: `<has-inline-comments>`, `<has-body-note>`, `<publish
 1. Assign a grade based on code quality (1-5 stars)
 2. If grade is below `★★★★★` without supporting feedback (inline comments or body note), you MUST add feedback - never publish a low grade without explaining why
 <% if (it.config.shared.prApprove === true) { -%>
-3. **NEVER post a review with `★★★★★`** - if the final grade is 5 stars, approve the PR instead
+3. If the final grade is `★★★★★`, try to approve the PR instead of posting a 5-star review comment
+4. If that approval attempt fails for any reason, immediately fall back to a review with `review.body` starting with `★★★★★`
 <% } else { -%>
 3. If the final grade is `★★★★★`, publish it as review feedback with `★★★★★` at the start of `review.body`
 <% } -%>
-4. If there are issues (grade < 5 stars), create inline comments on specific lines
+5. If there are issues (grade < 5 stars), create inline comments on specific lines
 
 **Inline comment format:**
 ```json
@@ -75,7 +76,10 @@ For multi-line: add `startLine`. For deleted lines: use `side: "LEFT"`.
 **If `<publish-grade>` is `★★★★★`:**
 <% if (it.config.shared.prApprove === true) { -%>
 - Already approved → skip
-- Otherwise → `pr_sync` with `refUrl: <pr-context.pr.url>` and only `review.approve: true`
+- Otherwise → first call `pr_sync` with `refUrl: <pr-context.pr.url>` and only `review.approve: true`
+- If that approval call fails, immediately call `pr_sync` again with `refUrl: <pr-context.pr.url>` and `review.body` starting with `★★★★★`
+- If there are no positive summary notes for the fallback review, the fallback body must be exactly `★★★★★`
+- Do not pass `review.comments` in the approval attempt or the fallback review
 <% } else { -%>
 - `pr_sync` with `refUrl: <pr-context.pr.url>` and `review.body` starting with `★★★★★`
 - If there are no positive summary notes, the body must be exactly `★★★★★`
@@ -102,6 +106,8 @@ When approved:
 PR approved for #<pr-context.pr.number>
 
 - PR URL: <pr-context.pr.url>
+
+No additional steps are required.
 ```
 
 When approval skipped (already approved):
@@ -109,6 +115,8 @@ When approval skipped (already approved):
 Approval skipped for PR #<pr-context.pr.number>
 
 - Reason: current head already approved
+
+No additional steps are required.
 ```
 <% } -%>
 When review published:
@@ -117,6 +125,8 @@ Review submitted for PR #<pr-context.pr.number>
 
 - Grade: <publish-grade>
 - Review URL: <review-url>
+
+No additional steps are required.
 ```
 
 When review skipped (no new feedback):
@@ -124,4 +134,6 @@ When review skipped (no new feedback):
 Review skipped for PR #<pr-context.pr.number>
 
 - Reason: no new inline comments or feedback
+
+No additional steps are required.
 ```

--- a/packages/core/commands/reload.md
+++ b/packages/core/commands/reload.md
@@ -29,4 +29,6 @@ $ARGUMENTS
 When reload succeeds, display:
 ```
 Reloaded project cache
+
+No additional steps are required.
 ```

--- a/packages/core/commands/review.md
+++ b/packages/core/commands/review.md
@@ -62,4 +62,6 @@ Review complete for <scope-description>
 - Grade: <star-rating>
 - Verdict: <short-verdict>
 - Findings: <count> total (<critical> critical, <high> high, <medium> medium, <low> low)
+
+No additional steps are required.
 ```

--- a/packages/core/commands/rmslop.md
+++ b/packages/core/commands/rmslop.md
@@ -70,6 +70,8 @@ Use `<additional-context>` to decide which kinds of slop to prioritize and which
 If there is no branch work to clean up, display:
 ```
 Nothing to clean for <scope-summary>
+
+No additional steps are required.
 ```
 
 When the cleanup is complete, display:
@@ -80,4 +82,6 @@ Results:
 - Files updated: <files-updated>
 - Validation: <validation-status>
 - Commit: <hash>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/ship.md
+++ b/packages/core/commands/ship.md
@@ -62,6 +62,8 @@ Use `<branch-context>` to steer delegated branch naming. Use `<additional-contex
 If there is nothing to ship, display:
 ```
 Nothing to ship
+
+No additional steps are required.
 ```
 
 When complete, display:
@@ -71,4 +73,6 @@ Ship flow complete
 Branch: <branch-result>
 Commit: <commit-result>
 PR: <pr-result>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/ticket/ask.md
+++ b/packages/core/commands/ticket/ask.md
@@ -46,9 +46,13 @@ $ARGUMENTS
 If the ticket context or question cannot be determined, display:
 ```
 Unable to answer ticket: missing ticket or question context
+
+No additional steps are required.
 ```
 
 When the ticket answer is posted, display:
 ```
 Answered ticket: <ticket-url>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/ticket/create.md
+++ b/packages/core/commands/ticket/create.md
@@ -45,10 +45,14 @@ Consider `<additional-context>` when analyzing the work and writing the ticket t
 If there is no work to summarize, display:
 ```
 Nothing to turn into a ticket
+
+No additional steps are required.
 ```
 
 When the ticket is created, display:
 ```
 Title: `<ticket-title>`
 URL: `<ticket-url>`
+
+No additional steps are required.
 ```

--- a/packages/core/commands/ticket/dev.md
+++ b/packages/core/commands/ticket/dev.md
@@ -93,4 +93,6 @@ Implementation: <implementation-result>
 Branch: <branch-result>
 Commit and push: <commit-result>
 PR: <pr-url>
+
+No additional steps are required.
 ```

--- a/packages/core/commands/ticket/plan.md
+++ b/packages/core/commands/ticket/plan.md
@@ -63,10 +63,14 @@ $ARGUMENTS
 If planning context cannot be determined, display:
 ```
 Unable to plan: missing request or ticket context
+
+No additional steps are required.
 ```
 
 When the plan is ready, display:
 ```
 Title: `<plan-title>`
 URL: `<ticket-url>`
+
+No additional steps are required.
 ```

--- a/packages/core/commands/todo.md
+++ b/packages/core/commands/todo.md
@@ -119,10 +119,14 @@ If the workflow pauses before marking the task complete, display:
 Todo paused: <todo-file>
 Task: <task>
 Reason: <pause-reason>
+
+No additional steps are required.
 ```
 
 When all pending tasks are complete, display:
 ```
 Todo complete: <todo-file>
 Remaining: 0
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/ask.md
+++ b/packages/opencode/.opencode/commands/ask.md
@@ -44,6 +44,13 @@ $ARGUMENTS
 If the question cannot be determined, display:
 ```
 Unable to answer: missing question
+
+No additional steps are required.
 ```
 
-When the answer is ready, display the answer directly.
+When the answer is ready, display:
+```
+<answer>
+
+No additional steps are required.
+```

--- a/packages/opencode/.opencode/commands/branch.md
+++ b/packages/opencode/.opencode/commands/branch.md
@@ -63,11 +63,15 @@ Use `<branch-context>` to steer the branch category and slug while keeping the f
 If there is nothing to branch from, display:
 ```
 Nothing to branch from
+
+No additional steps are required.
 ```
 
 If branching is skipped because the current branch already looks like a work branch, display:
 ```
 Already on work branch: <current-branch>
+
+No additional steps are required.
 ```
 
 When the branch is created, display:
@@ -75,4 +79,6 @@ When the branch is created, display:
 Created branch: <new-branch>
 
 From: <current-branch>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/commit-and-push.md
+++ b/packages/opencode/.opencode/commands/commit-and-push.md
@@ -86,6 +86,8 @@ Consider `<additional-context>` when analyzing changes and writing the commit me
 If there is nothing to commit, display:
 ```
 Nothing to commit or push
+
+No additional steps are required.
 ```
 
 When complete, display:
@@ -95,4 +97,6 @@ Created commit `<hash>`:
 <commit-message>
 
 Pushed to <push-target>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/commit.md
+++ b/packages/opencode/.opencode/commands/commit.md
@@ -79,6 +79,8 @@ Consider `<additional-context>` when analyzing changes and writing the commit me
 If there is nothing to commit, display:
 ```
 Nothing to commit
+
+No additional steps are required.
 ```
 
 When the commit is created, display:
@@ -86,4 +88,6 @@ When the commit is created, display:
 Created commit `<hash>`:
 
 <commit-message>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/dev.md
+++ b/packages/opencode/.opencode/commands/dev.md
@@ -73,5 +73,7 @@ Implementation ready: <request-summary>
 Validation:
 <validation-results>
 
-Next: create a PR for <branch>
+Ready for PR creation on <branch>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/learn.md
+++ b/packages/opencode/.opencode/commands/learn.md
@@ -77,4 +77,6 @@ Documented learnings for <focus-summary>
 
 Files updated:
 <file-update-lines>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/pr/create.md
+++ b/packages/opencode/.opencode/commands/pr/create.md
@@ -167,6 +167,8 @@ Consider `<additional-context>` when analyzing changes and writing the PR descri
 If PR creation stops because there is nothing to include, display:
 ```
 Nothing to include in a PR
+
+No additional steps are required.
 ```
 
 When a new PR is created, display:
@@ -176,6 +178,10 @@ Created PR: <pr-title>
 URL: <pr-url>
 Branch: <current-branch> → <resolved-base>
 Ticket: <ticket-url>
+<push-status>
+<pushed-line>
+
+No additional steps are required.
 ```
 
 If a PR already exists for the branch, display:
@@ -185,14 +191,8 @@ PR already exists
 URL: <pr-url>
 Branch: <current-branch> → <resolved-base>
 Ticket: <ticket-url>
-```
-
-After the ticket line, always include one additional line reporting push status:
-```
 <push-status>
-```
-
-If a push happened during this run, include one more line:
-```
 <pushed-line>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -134,10 +134,11 @@ When fixes are complete, display exactly this final completion summary and stop.
 ```
 PR fix complete for #<pr-context.pr.number>
 
-- Status: complete, no additional steps needed
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>
 - Validation passing: <validation-passing>
 - Validation details: <validation-results>
 - Pushed: <pushed>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/pr/review.md
+++ b/packages/opencode/.opencode/commands/pr/review.md
@@ -68,8 +68,9 @@ Before publishing, derive: `<has-inline-comments>`, `<has-body-note>`, `<publish
 **Grading and Publishing Rules:**
 1. Assign a grade based on code quality (1-5 stars)
 2. If grade is below `★★★★★` without supporting feedback (inline comments or body note), you MUST add feedback - never publish a low grade without explaining why
-3. **NEVER post a review with `★★★★★`** - if the final grade is 5 stars, approve the PR instead
-4. If there are issues (grade < 5 stars), create inline comments on specific lines
+3. If the final grade is `★★★★★`, try to approve the PR instead of posting a 5-star review comment
+4. If that approval attempt fails for any reason, immediately fall back to a review with `review.body` starting with `★★★★★`
+5. If there are issues (grade < 5 stars), create inline comments on specific lines
 
 **Inline comment format:**
 ```json
@@ -84,7 +85,10 @@ For multi-line: add `startLine`. For deleted lines: use `side: "LEFT"`.
 
 **If `<publish-grade>` is `★★★★★`:**
 - Already approved → skip
-- Otherwise → `kompass_pr_sync` with `refUrl: <pr-context.pr.url>` and only `review.approve: true`
+- Otherwise → first call `kompass_pr_sync` with `refUrl: <pr-context.pr.url>` and only `review.approve: true`
+- If that approval call fails, immediately call `kompass_pr_sync` again with `refUrl: <pr-context.pr.url>` and `review.body` starting with `★★★★★`
+- If there are no positive summary notes for the fallback review, the fallback body must be exactly `★★★★★`
+- Do not pass `review.comments` in the approval attempt or the fallback review
 
 **If `<publish-grade>` is below `★★★★★`:**
 - Call `kompass_pr_sync` with:
@@ -106,6 +110,8 @@ When approved:
 PR approved for #<pr-context.pr.number>
 
 - PR URL: <pr-context.pr.url>
+
+No additional steps are required.
 ```
 
 When approval skipped (already approved):
@@ -113,6 +119,8 @@ When approval skipped (already approved):
 Approval skipped for PR #<pr-context.pr.number>
 
 - Reason: current head already approved
+
+No additional steps are required.
 ```
 When review published:
 ```
@@ -120,6 +128,8 @@ Review submitted for PR #<pr-context.pr.number>
 
 - Grade: <publish-grade>
 - Review URL: <review-url>
+
+No additional steps are required.
 ```
 
 When review skipped (no new feedback):
@@ -127,4 +137,6 @@ When review skipped (no new feedback):
 Review skipped for PR #<pr-context.pr.number>
 
 - Reason: no new inline comments or feedback
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/reload.md
+++ b/packages/opencode/.opencode/commands/reload.md
@@ -34,4 +34,6 @@ $ARGUMENTS
 When kompass_reload succeeds, display:
 ```
 Reloaded project cache
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/review.md
+++ b/packages/opencode/.opencode/commands/review.md
@@ -67,4 +67,6 @@ Review complete for <scope-description>
 - Grade: <star-rating>
 - Verdict: <short-verdict>
 - Findings: <count> total (<critical> critical, <high> high, <medium> medium, <low> low)
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/rmslop.md
+++ b/packages/opencode/.opencode/commands/rmslop.md
@@ -74,6 +74,8 @@ Use `<additional-context>` to decide which kinds of slop to prioritize and which
 If there is no branch work to clean up, display:
 ```
 Nothing to clean for <scope-summary>
+
+No additional steps are required.
 ```
 
 When the cleanup is complete, display:
@@ -84,4 +86,6 @@ Results:
 - Files updated: <files-updated>
 - Validation: <validation-status>
 - Commit: <hash>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/ship.md
+++ b/packages/opencode/.opencode/commands/ship.md
@@ -67,6 +67,8 @@ Use `<branch-context>` to steer delegated branch naming. Use `<additional-contex
 If there is nothing to ship, display:
 ```
 Nothing to ship
+
+No additional steps are required.
 ```
 
 When complete, display:
@@ -76,4 +78,6 @@ Ship flow complete
 Branch: <branch-result>
 Commit: <commit-result>
 PR: <pr-result>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/ticket/ask.md
+++ b/packages/opencode/.opencode/commands/ticket/ask.md
@@ -55,9 +55,13 @@ $ARGUMENTS
 If the ticket context or question cannot be determined, display:
 ```
 Unable to answer ticket: missing ticket or question context
+
+No additional steps are required.
 ```
 
 When the ticket answer is posted, display:
 ```
 Answered ticket: <ticket-url>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/ticket/create.md
+++ b/packages/opencode/.opencode/commands/ticket/create.md
@@ -80,10 +80,14 @@ Consider `<additional-context>` when analyzing the work and writing the ticket t
 If there is no work to summarize, display:
 ```
 Nothing to turn into a ticket
+
+No additional steps are required.
 ```
 
 When the ticket is created, display:
 ```
 Title: `<ticket-title>`
 URL: `<ticket-url>`
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/ticket/dev.md
+++ b/packages/opencode/.opencode/commands/ticket/dev.md
@@ -108,4 +108,6 @@ Implementation: <implementation-result>
 Branch: <branch-result>
 Commit and push: <commit-result>
 PR: <pr-url>
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/ticket/plan.md
+++ b/packages/opencode/.opencode/commands/ticket/plan.md
@@ -72,10 +72,14 @@ $ARGUMENTS
 If planning context cannot be determined, display:
 ```
 Unable to plan: missing request or ticket context
+
+No additional steps are required.
 ```
 
 When the plan is ready, display:
 ```
 Title: `<plan-title>`
 URL: `<ticket-url>`
+
+No additional steps are required.
 ```

--- a/packages/opencode/.opencode/commands/todo.md
+++ b/packages/opencode/.opencode/commands/todo.md
@@ -124,10 +124,14 @@ If the workflow pauses before marking the task complete, display:
 Todo paused: <todo-file>
 Task: <task>
 Reason: <pause-reason>
+
+No additional steps are required.
 ```
 
 When all pending tasks are complete, display:
 ```
 Todo complete: <todo-file>
 Remaining: 0
+
+No additional steps are required.
 ```


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Clarify command authoring guidance so terminal command docs always end with an explicit terminal completion line and keep generated OpenCode command artifacts aligned with that contract.

## Checklist
### Command output contract
- [x] Require one-off command outcomes to end with `No additional steps are required.`
- [x] Make success, blocked, and no-op outputs explicit where needed

### Core command docs
- [x] Update command definitions across the core command set to use the terminal output pattern
- [x] Adjust related review guidance where the completion language changed

### Generated OpenCode artifacts
- [x] Regenerate `packages/opencode/.opencode/commands/` to match the source command docs

### Validation
- [x] Verify command output examples remain consistent between `packages/core/commands/` and `packages/opencode/.opencode/commands/`
- [ ] Confirm the terminal completion line is present for terminal one-off command outcomes