### PR TITLE
Handle no-change PR fix review flows

### DIFF
--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -83,7 +83,7 @@ Run the most relevant available validation for the fixes:
 ### Apply Review Feedback
 
 - Use `<review-feedback>` to refine the implementation without widening scope unless the feedback explicitly asks for it
-- Return to `### Implement Fixes`, then rerun validation and the approval step
+- Return to `### Implement Fixes`, then rerun validation and the review step
 
 ### Commit And Push Updates
 

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -94,7 +94,7 @@ Run the most relevant available validation for the fixes:
 ### Apply Review Feedback
 
 - Use `<review-feedback>` to refine the implementation without widening scope unless the feedback explicitly asks for it
-- Return to `### Implement Fixes`, then rerun validation and the approval step
+- Return to `### Implement Fixes`, then rerun validation and the review step
 
 ### Commit And Push Updates
 


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Update the PR fix command so review-mode runs handle passes with no code changes more explicitly and stop cleanly when the user chooses not to continue.

## Checklist
### No-change review flow
- [x] Add a dedicated no-change prompt that asks whether to revise again or stop
- [x] Define stop behavior when a review pass produces no file changes

### Generated command output
- [x] Keep the generated OpenCode command in sync with the source command

### Validation
- [x] Verify that no-change review passes can stop without commit, push, or PR replies
- [x] Confirm that review passes with changes still require explicit approval before continuing