### PR TITLE
refactor: use dispatch blocks for navigator delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,8 @@ packages/opencode/.opencode/ # Generated OpenCode output for review
 - Prefer explicit subsection names like `### Load ... Context`, `### Check Blockers`, `### Delegate ...`, and `### Mark Complete And Loop` when the command coordinates multiple phases or subagents
 - Treat loader tools and provided attachments as the source of truth for orchestration inputs; avoid extra exploratory commands when an existing tool result already answers the question
 - Before delegating to a subagent, say what result should be stored and whether the workflow must stop, pause, or continue based on that result
-- When delegating work to a subagent, define the exact delegated task inside literal `<task>` tags with required `agent` and optional `command` attributes; the navigator treats that block as a literal dispatch instruction and must send it exactly as written
+- Use literal `<dispatch>` tags when the workflow must forward exact text as the next user message to a subagent session; `agent` is required, the block body is the exact rendered message to send, and slash commands belong on the first line of the body when needed
+- Do not use `<task>` blocks in command docs; author navigator delegation with `<dispatch>` blocks only
 - When a command can pause for approval or loop over repeated work, describe the resume condition and the exact cases that must STOP without mutating state
 - Use `## Additional Context` for instructions about how optional guidance, related tickets, focus areas, or other stored context should influence analysis and output
 - Use `## Output` to define the exact user-facing response shape, including placeholders for generated values
@@ -92,23 +93,25 @@ $ARGUMENTS
 
 ### Delegate Planning
 
-<task agent="planner" command="/ticket/plan">
+<dispatch agent="planner">
+/ticket/plan
 
 Task: <task>
 Task context: <task-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<plan>`
 - STOP if planning is blocked or unusable
 
 ### Delegate Implementation
 
-<task agent="general" command="/dev">
+<dispatch agent="general">
+/dev
 
 Plan: <plan>
 Constraints: <additional-context>
-</task>
+</dispatch>
 
 - STOP if implementation is blocked or incomplete
 
@@ -125,7 +128,13 @@ Constraints: <additional-context>
 Example delegation rule:
 
 ```text
-Before delegating, write the exact `<task ...>...</task>` block, say what result should be stored, and whether the workflow should continue or STOP based on that result.
+Before delegating, write the exact `<dispatch ...>...</dispatch>` block, say what result should be stored, and whether the workflow should continue or STOP based on that result.
+```
+
+Example literal dispatch rule:
+
+```text
+Before literal command forwarding, write the exact `<dispatch ...>...</dispatch>` block, put the slash command on the first line of the body when needed, and say what result should be stored and whether the workflow should continue or STOP based on that result.
 ```
 
 ## Component Authoring

--- a/packages/core/agents/navigator.md
+++ b/packages/core/agents/navigator.md
@@ -11,16 +11,19 @@ You are a navigation specialist for structured, multi-step workflows.
 - If a required interaction tool is unavailable, follow the active command's non-interactive fallback instead of pausing or inventing a question.
 - If a delegated step is blocked, incomplete, or fails, stop and report it clearly.
 
-## Task Blocks
+## Dispatch Blocks
 
-- Treat each `<task agent="AGENT_NAME" command="COMMAND_NAME">...</task>` block as a literal delegation instruction.
+- Treat each `<dispatch agent="AGENT_NAME">...</dispatch>` block as a literal message dispatch instruction.
 - `agent` is required and names the exact subagent to invoke.
-- `command` is optional and sets the command context for that task.
-- Dispatch valid task blocks exactly as written. Do not summarize, rewrite, normalize, or merge task bodies.
-- Process every valid task block you receive.
-- Run independent task blocks in parallel only when the workflow makes that independence clear; otherwise run them sequentially in source order.
-- If a task block is malformed, report it as invalid, explain why briefly, and continue with remaining valid blocks when safe.
-- If no valid task blocks are present, continue with the command workflow.
+- The block body is the exact user message to send.
+- Do not summarize, rewrite, normalize, interpret, or improve the body.
+- Preserve line breaks and ordering exactly after variable substitution.
+- Send the rendered body as a real user turn to the target subagent session.
+- Never infer what a slash command means when handling a dispatch block. Forward it literally.
+- Process every valid dispatch block you receive.
+- Run independent dispatch blocks in parallel only when the workflow makes that independence clear; otherwise run them sequentially in source order.
+- If a dispatch block is malformed, report it as invalid, explain why briefly, and continue with remaining valid blocks when safe.
+- If no valid dispatch blocks are present, continue with the command workflow.
 
 ## Delegation
 

--- a/packages/core/commands/ship.md
+++ b/packages/core/commands/ship.md
@@ -19,9 +19,10 @@ $ARGUMENTS
 
 ### Ensure Feature Branch
 
-<task agent="general" command="/branch">
+<dispatch agent="general">
+/branch
 Branch naming guidance: <branch-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<branch-result>`
 - If `<branch-result>` is blocked or incomplete, STOP and report the branch blocker
@@ -30,9 +31,10 @@ Branch naming guidance: <branch-context>
 
 ### Delegate Commit
 
-<task agent="general" command="/commit">
+<dispatch agent="general">
+/commit
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<commit-result>`
 
@@ -42,10 +44,11 @@ Additional context: <additional-context>
 
 ### Delegate PR Creation
 
-<task agent="general" command="/pr/create">
+<dispatch agent="general">
+/pr/create
 Base branch: <base>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<pr-result>`
 

--- a/packages/core/commands/ticket/dev.md
+++ b/packages/core/commands/ticket/dev.md
@@ -27,25 +27,27 @@ $ARGUMENTS
 
 ### Delegate Implementation
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/dev">
+<dispatch agent="general">
+/dev
 Ticket reference: <ticket-ref>
 Ticket context: <ticket-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<implementation-result>`
 - If `<implementation-result>` is blocked or incomplete, STOP and report the implementation blocker
 
 ### Delegate Branch Creation
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/branch">
+<dispatch agent="general">
+/branch
 Branch naming guidance: <ticket-summary>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<branch-result>`
 - If `<branch-result>` is blocked or incomplete, STOP and report the branch blocker
@@ -53,13 +55,14 @@ Additional context: <additional-context>
 
 ### Delegate Commit And Push
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/commit-and-push">
+<dispatch agent="general">
+/commit-and-push
 Ticket reference: <ticket-ref>
 Ticket summary: <ticket-summary>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<commit-result>`
 - If `<commit-result>` is blocked or incomplete, STOP and report the commit or push blocker
@@ -67,13 +70,14 @@ Additional context: <additional-context>
 
 ### Delegate PR Creation
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/pr/create">
+<dispatch agent="general">
+/pr/create
 Ticket reference: <ticket-ref>
 Ticket context: <ticket-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<pr-result>`
 - If `<pr-result>` is blocked or incomplete, STOP and report the PR blocker

--- a/packages/core/commands/todo.md
+++ b/packages/core/commands/todo.md
@@ -34,11 +34,12 @@ $ARGUMENTS
 
 ### Delegate Planning
 
-<task agent="planner" command="/ticket/plan">
+<dispatch agent="planner">
+/ticket/plan
 Task: <task>
 Task context: <task-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Ask the planner for a concise implementation plan with clear scope, risks, and validation steps
 - Store the result as `<plan>`
@@ -55,13 +56,14 @@ Additional context: <additional-context>
     - `Revise` - update the plan based on feedback
 - custom answers enabled so the user can provide specific plan changes
 - If the user requests changes, store that feedback as `<user-answer>`
-<task agent="planner" command="/ticket/plan">
+<dispatch agent="planner">
+/ticket/plan
 Task: <task>
 Task context: <task-context>
 Current plan: <plan>
 Plan feedback: <user-answer>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the revised result as `<plan>` and continue the review loop
 - If the revised planner result is blocked or unusable, store that blocker as `<pause-reason>`, then STOP and report it before continuing the review loop
@@ -70,22 +72,24 @@ Additional context: <additional-context>
 
 ### Delegate Implementation
 
-<task agent="general" command="/dev">
+<dispatch agent="general">
+/dev
 Plan: <plan>
 Task: <task>
 Task context: <task-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<implementation-result>`
 - If `<implementation-result>` is incomplete, blocked, or fails validation, store the issue as `<pause-reason>`, then STOP and report it without marking the task complete
 
 ### Delegate Commit
 
-<task agent="general" command="/commit">
+<dispatch agent="general">
+/commit
 Task: <task>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<commit-result>`
 - If `<commit-result>` does not succeed, store the commit status as `<pause-reason>`, then STOP and report it without marking the task complete

--- a/packages/opencode/.opencode/agents/navigator.md
+++ b/packages/opencode/.opencode/agents/navigator.md
@@ -20,16 +20,19 @@ You are a navigation specialist for structured, multi-step workflows.
 - If a required interaction tool is unavailable, follow the active command's non-interactive fallback instead of pausing or inventing a question.
 - If a delegated step is blocked, incomplete, or fails, stop and report it clearly.
 
-## Task Blocks
+## Dispatch Blocks
 
-- Treat each `<task agent="AGENT_NAME" command="COMMAND_NAME">...</task>` block as a literal delegation instruction.
+- Treat each `<dispatch agent="AGENT_NAME">...</dispatch>` block as a literal message dispatch instruction.
 - `agent` is required and names the exact subagent to invoke.
-- `command` is optional and sets the command context for that task.
-- Dispatch valid task blocks exactly as written. Do not summarize, rewrite, normalize, or merge task bodies.
-- Process every valid task block you receive.
-- Run independent task blocks in parallel only when the workflow makes that independence clear; otherwise run them sequentially in source order.
-- If a task block is malformed, report it as invalid, explain why briefly, and continue with remaining valid blocks when safe.
-- If no valid task blocks are present, continue with the command workflow.
+- The block body is the exact user message to send.
+- Do not summarize, rewrite, normalize, interpret, or improve the body.
+- Preserve line breaks and ordering exactly after variable substitution.
+- Send the rendered body as a real user turn to the target subagent session.
+- Never infer what a slash command means when handling a dispatch block. Forward it literally.
+- Process every valid dispatch block you receive.
+- Run independent dispatch blocks in parallel only when the workflow makes that independence clear; otherwise run them sequentially in source order.
+- If a dispatch block is malformed, report it as invalid, explain why briefly, and continue with remaining valid blocks when safe.
+- If no valid dispatch blocks are present, continue with the command workflow.
 
 ## Delegation
 

--- a/packages/opencode/.opencode/commands/ship.md
+++ b/packages/opencode/.opencode/commands/ship.md
@@ -24,9 +24,10 @@ $ARGUMENTS
 
 ### Ensure Feature Branch
 
-<task agent="general" command="/branch">
+<dispatch agent="general">
+/branch
 Branch naming guidance: <branch-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<branch-result>`
 - If `<branch-result>` is blocked or incomplete, STOP and report the branch blocker
@@ -35,9 +36,10 @@ Branch naming guidance: <branch-context>
 
 ### Delegate Commit
 
-<task agent="general" command="/commit">
+<dispatch agent="general">
+/commit
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<commit-result>`
 
@@ -47,10 +49,11 @@ Additional context: <additional-context>
 
 ### Delegate PR Creation
 
-<task agent="general" command="/pr/create">
+<dispatch agent="general">
+/pr/create
 Base branch: <base>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<pr-result>`
 

--- a/packages/opencode/.opencode/commands/ticket/dev.md
+++ b/packages/opencode/.opencode/commands/ticket/dev.md
@@ -42,25 +42,27 @@ $ARGUMENTS
 
 ### Delegate Implementation
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/dev">
+<dispatch agent="general">
+/dev
 Ticket reference: <ticket-ref>
 Ticket context: <ticket-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<implementation-result>`
 - If `<implementation-result>` is blocked or incomplete, STOP and report the implementation blocker
 
 ### Delegate Branch Creation
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/branch">
+<dispatch agent="general">
+/branch
 Branch naming guidance: <ticket-summary>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<branch-result>`
 - If `<branch-result>` is blocked or incomplete, STOP and report the branch blocker
@@ -68,13 +70,14 @@ Additional context: <additional-context>
 
 ### Delegate Commit And Push
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/commit-and-push">
+<dispatch agent="general">
+/commit-and-push
 Ticket reference: <ticket-ref>
 Ticket summary: <ticket-summary>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<commit-result>`
 - If `<commit-result>` is blocked or incomplete, STOP and report the commit or push blocker
@@ -82,13 +85,14 @@ Additional context: <additional-context>
 
 ### Delegate PR Creation
 
-- Before delegating, send the exact task block below
+- Before delegating, send the exact dispatch block below
 
-<task agent="general" command="/pr/create">
+<dispatch agent="general">
+/pr/create
 Ticket reference: <ticket-ref>
 Ticket context: <ticket-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the result as `<pr-result>`
 - If `<pr-result>` is blocked or incomplete, STOP and report the PR blocker

--- a/packages/opencode/.opencode/commands/todo.md
+++ b/packages/opencode/.opencode/commands/todo.md
@@ -39,11 +39,12 @@ $ARGUMENTS
 
 ### Delegate Planning
 
-<task agent="planner" command="/ticket/plan">
+<dispatch agent="planner">
+/ticket/plan
 Task: <task>
 Task context: <task-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Ask the planner for a concise implementation plan with clear scope, risks, and validation steps
 - Store the result as `<plan>`
@@ -60,13 +61,14 @@ Additional context: <additional-context>
     - `Revise` - update the plan based on feedback
 - custom answers enabled so the user can provide specific plan changes
 - If the user requests changes, store that feedback as `<user-answer>`
-<task agent="planner" command="/ticket/plan">
+<dispatch agent="planner">
+/ticket/plan
 Task: <task>
 Task context: <task-context>
 Current plan: <plan>
 Plan feedback: <user-answer>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the revised result as `<plan>` and continue the review loop
 - If the revised planner result is blocked or unusable, store that blocker as `<pause-reason>`, then STOP and report it before continuing the review loop
@@ -75,22 +77,24 @@ Additional context: <additional-context>
 
 ### Delegate Implementation
 
-<task agent="general" command="/dev">
+<dispatch agent="general">
+/dev
 Plan: <plan>
 Task: <task>
 Task context: <task-context>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<implementation-result>`
 - If `<implementation-result>` is incomplete, blocked, or fails validation, store the issue as `<pause-reason>`, then STOP and report it without marking the task complete
 
 ### Delegate Commit
 
-<task agent="general" command="/commit">
+<dispatch agent="general">
+/commit
 Task: <task>
 Additional context: <additional-context>
-</task>
+</dispatch>
 
 - Store the subagent result as `<commit-result>`
 - If `<commit-result>` does not succeed, store the commit status as `<pause-reason>`, then STOP and report it without marking the task complete

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -424,7 +424,7 @@ describe("applyCommandsConfig", () => {
       assert.ok(cfg.command!["review"]?.template);
     });
 
-    test("embeds direct task delegation in ship command", async () => {
+    test("embeds literal dispatch blocks in ship command", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { template: string }> } = {};
 
@@ -436,12 +436,13 @@ describe("applyCommandsConfig", () => {
       assert.match(shipTemplate, /## Goal/);
       assert.match(shipTemplate, /Ship the current work by delegating/);
       assert.match(shipTemplate, /Ensure Feature Branch/);
-      assert.match(shipTemplate, /<task agent="general" command="\/branch">/);
+      assert.match(shipTemplate, /<dispatch agent="general">/);
+      assert.match(shipTemplate, /\n\/branch\nBranch naming guidance: <branch-context>\n<\/dispatch>/);
       assert.match(shipTemplate, /Store the subagent result as `<branch-result>`/);
       assert.match(shipTemplate, /Store the subagent result as `<commit-result>`/);
-      assert.match(shipTemplate, /<task agent="general" command="\/commit">/);
+      assert.match(shipTemplate, /\n\/commit\nAdditional context: <additional-context>\n<\/dispatch>/);
       assert.match(shipTemplate, /Store the subagent result as `<pr-result>`/);
-      assert.match(shipTemplate, /<task agent="general" command="\/pr\/create">/);
+      assert.match(shipTemplate, /\n\/pr\/create\nBase branch: <base>\nAdditional context: <additional-context>\n<\/dispatch>/);
 
       assert.doesNotMatch(shipTemplate, /<%/);
     });
@@ -512,8 +513,35 @@ describe("applyCommandsConfig", () => {
       // PR Author content is now inline in pr/create, not embedded here
       assert.match(ticketDevTemplate, /## Goal/);
       assert.match(ticketDevTemplate, /Implement a ticket/);
-      
+      assert.match(ticketDevTemplate, /<dispatch agent="general">/);
+      assert.match(ticketDevTemplate, /\n\/dev\nTicket reference: <ticket-ref>\nTicket context: <ticket-context>\nAdditional context: <additional-context>\n<\/dispatch>/);
+      assert.match(ticketDevTemplate, /\n\/branch\nBranch naming guidance: <ticket-summary>\nAdditional context: <additional-context>\n<\/dispatch>/);
+      assert.match(ticketDevTemplate, /\n\/commit-and-push\nTicket reference: <ticket-ref>\nTicket summary: <ticket-summary>\nAdditional context: <additional-context>\n<\/dispatch>/);
+      assert.match(ticketDevTemplate, /\n\/pr\/create\nTicket reference: <ticket-ref>\nTicket context: <ticket-context>\nAdditional context: <additional-context>\n<\/dispatch>/);
+      assert.doesNotMatch(ticketDevTemplate, /<task agent=/);
+
       assert.doesNotMatch(ticketDevTemplate, /<%/);
+    });
+
+    test("embeds literal dispatch blocks in todo command", async () => {
+      delete process.env.CI;
+      const cfg: { command?: Record<string, { template: string }> } = {};
+
+      await applyCommandsConfig(cfg as never, process.cwd());
+
+      assert.ok(cfg.command);
+      const todoTemplate = cfg.command!["todo"].template;
+
+      assert.match(todoTemplate, /## Goal/);
+      assert.match(todoTemplate, /Work through a todo file one pending item at a time/);
+      assert.match(todoTemplate, /<dispatch agent="planner">/);
+      assert.match(todoTemplate, /\n\/ticket\/plan\nTask: <task>\nTask context: <task-context>\nAdditional context: <additional-context>\n<\/dispatch>/);
+      assert.match(todoTemplate, /Current plan: <plan>\nPlan feedback: <user-answer>/);
+      assert.match(todoTemplate, /\n\/dev\nPlan: <plan>\nTask: <task>\nTask context: <task-context>\nAdditional context: <additional-context>\n<\/dispatch>/);
+      assert.match(todoTemplate, /\n\/commit\nTask: <task>\nAdditional context: <additional-context>\n<\/dispatch>/);
+      assert.doesNotMatch(todoTemplate, /<task agent=/);
+
+      assert.doesNotMatch(todoTemplate, /<%/);
     });
   });
 


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Replace navigator task-block delegation with literal dispatch blocks so command docs forward exact subagent messages and rendered templates enforce the new format.

## Checklist
### Dispatch docs
- [x] Update authoring guidance and navigator instructions to use `<dispatch>` blocks instead of `<task>` blocks

### Command templates
- [x] Update ship, todo, and ticket development commands in core and generated OpenCode output to emit literal dispatch bodies

### Coverage
- [x] Extend command config tests to assert dispatch block rendering and reject legacy task blocks

### Validation
- [x] Verify command templates render dispatch blocks with slash commands on the first line
- [x] Check navigator guidance matches the new literal message dispatch behavior