### PR TITLE
Fix config loading and allow OpenCode defaults to be overridden

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - [x] Add support for approving PR on pr_sync too, so if it's 5 star, approve PR, no comments or grade needed
 - [x] Improve commit generation, it's currently too simpler and often one line... Check a few commits and the changes to understand... Create a better list of changes.
 - [ ] Only register command / agents / tools that aren't already registered, so if the user has already registered a custom pr_create command, we don't override it with the default one. This allows for more flexibility and customization.
+- [ ] Improve /pr/fix https://github.com/kompassdev/kompass/pull/52 to not send unnecessary commentBody, only send when no inline review

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -1,4 +1,5 @@
 import { access, readFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -232,9 +233,36 @@ export async function loadKompassConfig(
   projectRoot: string,
 ): Promise<KompassConfig> {
   const bundledConfig = await loadBundledConfig();
-  const projectConfig = await loadFirstConfig(projectRoot, PROJECT_CONFIG_FILES);
+  const configRoots = getConfigRoots(projectRoot);
 
-  return mergeConfigObjects(bundledConfig, projectConfig) ?? bundledConfig;
+  let mergedConfig: KompassConfig | null = bundledConfig;
+  for (const configRoot of configRoots) {
+    mergedConfig = mergeConfigObjects(
+      mergedConfig,
+      await loadFirstConfig(configRoot, PROJECT_CONFIG_FILES),
+    );
+  }
+
+  return mergedConfig ?? bundledConfig;
+}
+
+function getConfigRoots(projectRoot: string): string[] {
+  const roots: string[] = [];
+  const seen = new Set<string>();
+
+  const homeDirectory = process.env.HOME || os.homedir();
+  if (homeDirectory) {
+    const normalizedHome = path.resolve(homeDirectory);
+    seen.add(normalizedHome);
+    roots.push(normalizedHome);
+  }
+
+  const normalizedProjectRoot = path.resolve(projectRoot);
+  if (!seen.has(normalizedProjectRoot)) {
+    roots.push(normalizedProjectRoot);
+  }
+
+  return roots;
 }
 
 async function loadBundledConfig(): Promise<KompassConfig> {

--- a/packages/core/test/commands.test.ts
+++ b/packages/core/test/commands.test.ts
@@ -1,7 +1,11 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 
 import { resolveCommands } from "../commands/index.ts";
+
+process.env.HOME = path.join(os.tmpdir(), `kompass-test-home-${process.pid}-core-commands`);
 
 describe("resolveCommands", () => {
   test("includes root review config for pr/review", async () => {

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -6,128 +6,225 @@ import path from "node:path";
 
 import { isSkillEnabled, loadKompassConfig, mergeWithDefaults } from "../lib/config.ts";
 
+const originalHome = process.env.HOME;
+
+async function withTempHome<T>(run: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "kompass-home-"));
+
+  process.env.HOME = homeDir;
+
+  try {
+    return await run(homeDir);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
 describe("config loading", () => {
   test("parses .opencode jsonc config files", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-"));
 
-    try {
-      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.jsonc"),
-        `{
-          // jsonc should be supported
-          "commands": {
-            "dev": {
-              "enabled": false,
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            // jsonc should be supported
+            "commands": {
+              "dev": {
+                "enabled": false,
+              },
             },
-          },
-        }`,
-      );
+          }`,
+        );
 
-      const config = await loadKompassConfig(tempDir);
+        const config = await loadKompassConfig(tempDir);
 
-      assert.equal(config?.commands?.dev?.enabled, false);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+        assert.equal(config?.commands?.dev?.enabled, false);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 
   test("parses validation strings in jsonc config files", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-validation-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-validation-"));
 
-    try {
-      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.jsonc"),
-        `{
-          "shared": {
-            "validation": [
-              "Run lint if available",
-              "Run tests if available"
-            ]
-          }
-        }`,
-      );
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "validation": [
+                "Run lint if available",
+                "Run tests if available"
+              ]
+            }
+          }`,
+        );
 
-      const config = await loadKompassConfig(tempDir);
+        const config = await loadKompassConfig(tempDir);
 
-      assert.equal(
-        JSON.stringify(config.shared?.validation),
-        JSON.stringify(["Run lint if available", "Run tests if available"]),
-      );
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+        assert.equal(
+          JSON.stringify(config.shared?.validation),
+          JSON.stringify(["Run lint if available", "Run tests if available"]),
+        );
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 
   test("prefers project config files in documented order", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-order-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-order-"));
 
-    try {
-      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.json"),
-        JSON.stringify({ shared: { prApprove: false } }),
-      );
-      await writeFile(
-        path.join(tempDir, "kompass.jsonc"),
-        `{
-          "shared": {
-            "prApprove": false
-          },
-          "commands": {
-            "dev": {
-              "enabled": false
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.json"),
+          JSON.stringify({ shared: { prApprove: false } }),
+        );
+        await writeFile(
+          path.join(tempDir, "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": false
+            },
+            "commands": {
+              "dev": {
+                "enabled": false
+              }
             }
-          }
-        }`,
-      );
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.jsonc"),
-        `{
-          "shared": {
-            "prApprove": true
-          }
-        }`,
-      );
+          }`,
+        );
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": true
+            }
+          }`,
+        );
 
-      const config = await loadKompassConfig(tempDir);
+        const config = await loadKompassConfig(tempDir);
 
-      assert.equal(config.shared?.prApprove, true);
-      assert.equal(config.commands?.dev?.enabled, true);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+        assert.equal(config.shared?.prApprove, true);
+        assert.equal(config.commands?.dev?.enabled, true);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 
   test("merges bundled config with .opencode overrides", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-merge-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-merge-"));
 
-    try {
-      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.jsonc"),
-        `{
-          "shared": {
-            "prApprove": true
-          },
-          "commands": {
-            "dev": {
-              "enabled": false
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": true
+            },
+            "commands": {
+              "dev": {
+                "enabled": false
+              }
             }
-          }
-        }`,
-      );
+          }`,
+        );
 
-      const config = await loadKompassConfig(tempDir);
+        const config = await loadKompassConfig(tempDir);
 
-      assert.equal(config?.shared?.prApprove, true);
-      assert.equal(config?.defaults?.baseBranch, "main");
-      assert.equal(config?.commands?.dev?.enabled, false);
-      assert.equal(config?.commands?.review?.enabled, true);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+        assert.equal(config?.shared?.prApprove, true);
+        assert.equal(config?.defaults?.baseBranch, "main");
+        assert.equal(config?.commands?.dev?.enabled, false);
+        assert.equal(config?.commands?.review?.enabled, true);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test("falls back to home config when project has no override", async () => {
+    await withTempHome(async (homeDir) => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-home-fallback-"));
+
+      try {
+        await mkdir(path.join(homeDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(homeDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": true
+            },
+            "commands": {
+              "dev": {
+                "enabled": false
+              }
+            }
+          }`,
+        );
+
+        const config = await loadKompassConfig(tempDir);
+
+        assert.equal(config.shared?.prApprove, true);
+        assert.equal(config.commands?.dev?.enabled, false);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test("project config overrides home config", async () => {
+    await withTempHome(async (homeDir) => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-config-home-override-"));
+
+      try {
+        await mkdir(path.join(homeDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(homeDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": false
+            },
+            "commands": {
+              "dev": {
+                "enabled": false
+              }
+            }
+          }`,
+        );
+
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": true
+            }
+          }`,
+        );
+
+        const config = await loadKompassConfig(tempDir);
+
+        assert.equal(config.shared?.prApprove, true);
+        assert.equal(config.commands?.dev?.enabled, false);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 });
 

--- a/packages/opencode/config.ts
+++ b/packages/opencode/config.ts
@@ -82,7 +82,7 @@ export async function applyAgentsConfig(
       ...(definition.prompt ? { prompt: rewriteToolNames(definition.prompt) } : {}),
       ...(definition.mode ? { mode: definition.mode } : {}),
     };
-    cfg.agent[name] ??= agentConfig;
+    cfg.agent[name] = agentConfig;
 
     await options?.logger?.info("Loaded Kompass agent", {
         agent: name,
@@ -111,7 +111,7 @@ export async function applyCommandsConfig(
   cfg.command ??= {};
 
   for (const [name, definition] of Object.entries(commands)) {
-    cfg.command[name] ??= {
+    cfg.command[name] = {
       description: definition.description,
       agent: definition.agent,
       subtask: definition.subtask,

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -61,6 +61,18 @@ function getString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+async function logObservedFailure(
+  logger: PluginLogger,
+  message: string,
+  error: unknown,
+  extra?: Record<string, unknown>,
+) {
+  await logger.warn(message, {
+    ...(extra ?? {}),
+    ...getErrorDetails(error),
+  });
+}
+
 function parseSlashCommand(value: string): ParsedSlashCommand | undefined {
   const match = value.trim().match(/^(?:@\S+\s+)?\/([^\s]+)(?:\s+([\s\S]*))?$/);
 
@@ -141,11 +153,23 @@ export async function getTaskToolExecution(
 
   if (!prompt && !command) return;
 
-  const expandedCommand = command
-    ? await expandSlashCommandPrompt(projectRoot, command, logger)
-    : prompt
-      ? await expandSlashCommandPrompt(projectRoot, prompt, logger)
-      : undefined;
+  let expandedCommand: CommandExecution | undefined;
+  try {
+    expandedCommand = command
+      ? await expandSlashCommandPrompt(projectRoot, command, logger)
+      : prompt
+        ? await expandSlashCommandPrompt(projectRoot, prompt, logger)
+        : undefined;
+  } catch (error) {
+    if (logger) {
+      await logObservedFailure(logger, "Failed to expand slash command for task tool", error, {
+        projectRoot,
+        tool: input.tool,
+        command,
+        prompt,
+      });
+    }
+  }
   const finalPrompt = expandedCommand?.prompt ?? prompt ?? command ?? "";
 
   args.prompt = finalPrompt;
@@ -199,7 +223,9 @@ function createReloadTool(client: PluginInput["client"]) {
     async execute(_, context) {
       // Defer dispose so the tool returns before the session is torn down
       setTimeout(() => {
-        void client.instance.dispose({ query: { directory: context.directory } });
+        void client.instance.dispose({ query: { directory: context.directory } }).catch((error) => {
+          console.error("[kompass] Failed to dispose instance during reload:", error);
+        });
       }, 500);
       return JSON.stringify({
         scope: "project",
@@ -349,8 +375,15 @@ export async function createOpenCodeTools(
   return tools;
 }
 
-export const OpenCodeCompassPlugin: Plugin = async ({ $, client, worktree }: PluginInput) => {
+export const OpenCodeCompassPlugin: Plugin = async (input: PluginInput) => {
+  const { $, client, worktree } = input;
   const logger = createPluginLogger(client, worktree);
+
+  await logger.info("Initialized Kompass plugin", {
+    directory: getString(input.directory),
+    worktree: getString(worktree),
+    projectPath: getString((input as { project?: { path?: string } }).project?.path),
+  });
 
   async function createToolsSafely() {
     try {
@@ -385,29 +418,53 @@ export const OpenCodeCompassPlugin: Plugin = async ({ $, client, worktree }: Plu
       await runConfigStep("skills", () => applySkillsConfig(cfg, { logger }));
     },
     async "chat.message"(input, output) {
-      const removedSyntheticHandoff = removeSyntheticAgentHandoff(output);
+      try {
+        const removedSyntheticHandoff = removeSyntheticAgentHandoff(output);
 
-      if (!removedSyntheticHandoff) return;
+        if (!removedSyntheticHandoff) return;
 
-      await logger.info("Removed synthetic agent handoff text", {
-        sessionID: input.sessionID,
-        messageID: input.messageID,
-        agent: input.agent,
-      });
+        await logger.info("Removed synthetic agent handoff text", {
+          sessionID: input.sessionID,
+          messageID: input.messageID,
+          agent: input.agent,
+        });
+      } catch (error) {
+        await logObservedFailure(logger, "chat.message hook failed", error, {
+          sessionID: input.sessionID,
+          messageID: input.messageID,
+          agent: input.agent,
+        });
+      }
     },
     async "command.execute.before"(input, output) {
-      const commandExecution = getCommandExecution(input, output);
+      try {
+        const commandExecution = getCommandExecution(input, output);
 
-      if (!commandExecution) return;
+        if (!commandExecution) return;
 
-      await logger.info("Executing Kompass command", commandExecution as Record<string, unknown>);
+        await logger.info("Executing Kompass command", commandExecution as Record<string, unknown>);
+      } catch (error) {
+        await logObservedFailure(logger, "command.execute.before hook failed", error, {
+          command: input.command,
+          arguments: input.arguments,
+          sessionID: input.sessionID,
+        });
+      }
     },
     async "tool.execute.before"(input, output) {
-      const taskExecution = await getTaskToolExecution(input, output, worktree, logger);
+      try {
+        const taskExecution = await getTaskToolExecution(input, output, worktree, logger);
 
-      if (!taskExecution) return;
+        if (!taskExecution) return;
 
-      await logger.info("Executing Kompass task tool", taskExecution as Record<string, unknown>);
+        await logger.info("Executing Kompass task tool", taskExecution as Record<string, unknown>);
+      } catch (error) {
+        await logObservedFailure(logger, "tool.execute.before hook failed", error, {
+          tool: input.tool,
+          callID: input.callID,
+          sessionID: input.sessionID,
+        });
+      }
     },
   };
 };

--- a/packages/opencode/test/agents-config.test.ts
+++ b/packages/opencode/test/agents-config.test.ts
@@ -1,7 +1,11 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 
 import { applyAgentsConfig } from "../config.ts";
+
+process.env.HOME = path.join(os.tmpdir(), `kompass-test-home-${process.pid}-agents-config`);
 
 describe("applyAgentsConfig", () => {
   test("registers agents with their default permissions", async () => {
@@ -50,5 +54,35 @@ describe("applyAgentsConfig", () => {
     assert.match(cfg.agent.navigator?.prompt ?? "", /delegate only explicit leaf tasks/i);
     assert.match(cfg.agent.navigator?.prompt ?? "", /complete the local steps first/i);
     assert.match(cfg.agent.reviewer?.prompt ?? "", /Never switch branches/i);
+  });
+
+  test("overwrites existing agent configuration", async () => {
+    const cfg: {
+      agent?: Record<
+        string,
+        {
+          description: string;
+          prompt?: string;
+          permission: Record<string, string>;
+          mode?: string;
+        }
+      >;
+    } = {
+      agent: {
+        worker: {
+          description: "Existing worker",
+          prompt: "Existing prompt",
+          permission: { question: "deny" },
+        },
+      },
+    };
+
+    await applyAgentsConfig(cfg as never, process.cwd());
+
+    assert.equal(cfg.agent?.worker?.description, "Generic worker agent.");
+    assert.equal(cfg.agent?.worker?.prompt, undefined);
+    assert.deepEqual(cfg.agent?.worker?.permission, {
+      question: "allow",
+    });
   });
 });

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -7,6 +7,9 @@ import path from "node:path";
 import { applyCommandsConfig } from "../config.ts";
 
 const originalCi = process.env.CI;
+const isolatedHome = path.join(os.tmpdir(), `kompass-test-home-${process.pid}-commands-config`);
+
+process.env.HOME = isolatedHome;
 
 afterEach(() => {
   if (originalCi === undefined) {
@@ -14,6 +17,8 @@ afterEach(() => {
   } else {
     process.env.CI = originalCi;
   }
+
+  process.env.HOME = isolatedHome;
 });
 
 describe("applyCommandsConfig", () => {
@@ -361,8 +366,8 @@ describe("applyCommandsConfig", () => {
     });
   });
 
-  describe("existing command config preservation", () => {
-    test("preserves existing command configuration", async () => {
+  describe("existing command config overwrite", () => {
+    test("overwrites existing command configuration", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { description: string; template: string }> } = {
         command: {
@@ -375,11 +380,12 @@ describe("applyCommandsConfig", () => {
 
       await applyCommandsConfig(cfg as never, process.cwd());
 
-      assert.equal(cfg.command!["dev"].description, "Existing description");
-      assert.equal(cfg.command!["dev"].template, "Existing template");
+      assert.notEqual(cfg.command!["dev"].description, "Existing description");
+      assert.notEqual(cfg.command!["dev"].template, "Existing template");
+      assert.match(cfg.command!["dev"].template, /## Goal/);
     });
 
-    test("fills in missing commands while preserving existing ones", async () => {
+    test("overwrites existing commands and still registers the rest", async () => {
       delete process.env.CI;
       const cfg: { command?: Record<string, { description: string; template: string }> } = {
         command: {
@@ -392,11 +398,9 @@ describe("applyCommandsConfig", () => {
 
       await applyCommandsConfig(cfg as never, process.cwd());
 
-      // Existing command should be preserved
-      assert.equal(cfg.command!["dev"].description, "Custom dev description");
-      assert.equal(cfg.command!["dev"].template, "Custom dev template");
-      
-      // Other commands should still be registered
+      assert.notEqual(cfg.command!["dev"].description, "Custom dev description");
+      assert.notEqual(cfg.command!["dev"].template, "Custom dev template");
+
       assert.ok(cfg.command!["pr/review"]);
       assert.ok(cfg.command!["pr/create"]);
     });

--- a/packages/opencode/test/tool-registration.test.ts
+++ b/packages/opencode/test/tool-registration.test.ts
@@ -4,152 +4,253 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { createOpenCodeTools } from "../index.ts";
+import { createOpenCodeTools, OpenCodeCompassPlugin } from "../index.ts";
 
-function createMockClient() {
+type MockLogEntry = {
+  query?: { directory?: string };
+  body?: { level?: string; message?: string; extra?: Record<string, unknown> };
+};
+
+type MockClient = {
+  logs: MockLogEntry[];
+  app: {
+    log(entry: MockLogEntry): Promise<boolean>;
+  };
+  instance: {
+    dispose(): Promise<boolean>;
+  };
+};
+
+const originalHome = process.env.HOME;
+
+async function withTempHome<T>(run: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-home-"));
+
+  process.env.HOME = homeDir;
+
+  try {
+    return await run(homeDir);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+function createMockClient(): MockClient {
+  const logs: MockLogEntry[] = [];
+
   return {
+    logs,
     app: {
-      log: async () => true,
+      log: async (entry: (typeof logs)[number]) => {
+        logs.push(entry);
+        return true;
+      },
     },
     instance: {
       dispose: async () => true,
     },
-  } as never;
+  };
 }
 
 describe("createOpenCodeTools", () => {
   test("registers Kompass tools with prefixed names", async () => {
-    const tools = await createOpenCodeTools((() => {
-      throw new Error("not implemented");
-    }) as never, createMockClient(), process.cwd());
+    await withTempHome(async () => {
+      const tools = await createOpenCodeTools((() => {
+        throw new Error("not implemented");
+      }) as never, createMockClient() as never, process.cwd());
 
-    assert.ok(tools.kompass_changes_load);
-    assert.ok(tools.kompass_pr_load);
-    assert.ok(tools.kompass_pr_sync);
-    assert.ok(tools.kompass_reload);
-    assert.ok(tools.kompass_ticket_load);
-    assert.ok(tools.kompass_ticket_sync);
-    assert.equal(tools.changes_load, undefined);
-    assert.equal(tools.pr_load, undefined);
-    assert.equal(tools.pr_sync, undefined);
-    assert.equal(tools.reload, undefined);
-    assert.equal(tools.ticket_load, undefined);
-    assert.equal(tools.ticket_sync, undefined);
+      assert.ok(tools.kompass_changes_load);
+      assert.ok(tools.kompass_pr_load);
+      assert.ok(tools.kompass_pr_sync);
+      assert.ok(tools.kompass_reload);
+      assert.ok(tools.kompass_ticket_load);
+      assert.ok(tools.kompass_ticket_sync);
+      assert.equal(tools.changes_load, undefined);
+      assert.equal(tools.pr_load, undefined);
+      assert.equal(tools.pr_sync, undefined);
+      assert.equal(tools.reload, undefined);
+      assert.equal(tools.ticket_load, undefined);
+      assert.equal(tools.ticket_sync, undefined);
+    });
   });
 
   test("registers configured tool aliases instead of default prefixed names", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-"));
 
-    try {
-      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.jsonc"),
-        `{
-          "tools": {
-            "changes_load": { "enabled": false },
-            "pr_load": { "enabled": false },
-            "pr_sync": { "enabled": false },
-            "ticket_sync": {
-              "enabled": true,
-              "name": "custom_ticket_name"
-            },
-            "ticket_load": { "enabled": false }
-          }
-        }`,
-      );
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "tools": {
+              "changes_load": { "enabled": false },
+              "pr_load": { "enabled": false },
+              "pr_sync": { "enabled": false },
+              "ticket_sync": {
+                "enabled": true,
+                "name": "custom_ticket_name"
+              },
+              "ticket_load": { "enabled": false }
+            }
+          }`,
+        );
 
-      const tools = await createOpenCodeTools((() => {
-        throw new Error("not implemented");
-      }) as never, createMockClient(), tempDir);
+        const tools = await createOpenCodeTools((() => {
+          throw new Error("not implemented");
+        }) as never, createMockClient() as never, tempDir);
 
-      assert.ok(tools.custom_ticket_name);
-      assert.ok(tools.kompass_reload);
-      assert.equal(tools.kompass_ticket_sync, undefined);
-      assert.deepEqual(Object.keys(tools).sort(), ["custom_ticket_name", "kompass_reload"]);
+        assert.ok(tools.custom_ticket_name);
+        assert.ok(tools.kompass_reload);
+        assert.equal(tools.kompass_ticket_sync, undefined);
+        assert.deepEqual(Object.keys(tools).sort(), ["custom_ticket_name", "kompass_reload"]);
       } finally {
         await rm(tempDir, { recursive: true, force: true });
       }
+    });
   });
 
   test("loads tool aliases from jsonc config", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-jsonc-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-jsonc-"));
 
-    try {
-      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.jsonc"),
-        `{
-          // jsonc config should work
-          "tools": {
-            "pr_load": {
-              "enabled": true,
-              "name": "pull_request_context",
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            // jsonc config should work
+            "tools": {
+              "pr_load": {
+                "enabled": true,
+                "name": "pull_request_context",
+              },
             },
-          },
-        }`,
-      );
+          }`,
+        );
 
-      const tools = await createOpenCodeTools((() => {
-        throw new Error("not implemented");
-      }) as never, createMockClient(), tempDir);
+        const tools = await createOpenCodeTools((() => {
+          throw new Error("not implemented");
+        }) as never, createMockClient() as never, tempDir);
 
-      assert.ok(tools.pull_request_context);
-      assert.equal(tools.kompass_pr_load, undefined);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+        assert.ok(tools.pull_request_context);
+        assert.equal(tools.kompass_pr_load, undefined);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 
   test("hides review.approve when pr/review approval is disabled", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-no-approve-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-no-approve-"));
 
-    try {
-      const tools = await createOpenCodeTools((() => {
-        throw new Error("not implemented");
-      }) as never, createMockClient(), tempDir);
+      try {
+        const tools = await createOpenCodeTools((() => {
+          throw new Error("not implemented");
+        }) as never, createMockClient() as never, tempDir);
 
-      const reviewShape = (tools.kompass_pr_sync as any).args.review.unwrap().shape;
-      assert.equal(reviewShape.approve, undefined);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+        const reviewShape = (tools.kompass_pr_sync as any).args.review.unwrap().shape;
+        assert.equal(reviewShape.approve, undefined);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 
   test("includes review.approve when pr/review approval is enabled", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-approve-"));
+    await withTempHome(async () => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-approve-"));
 
-    try {
-      await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
-      await writeFile(
-        path.join(tempDir, ".opencode", "kompass.jsonc"),
-        `{
-          "shared": {
-            "prApprove": true
-          }
-        }`,
-      );
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": true
+            }
+          }`,
+        );
 
-      const tools = await createOpenCodeTools((() => {
-        throw new Error("not implemented");
-      }) as never, createMockClient(), tempDir);
+        const tools = await createOpenCodeTools((() => {
+          throw new Error("not implemented");
+        }) as never, createMockClient() as never, tempDir);
 
-      const reviewShape = (tools.kompass_pr_sync as any).args.review.unwrap().shape;
-      assert.ok(reviewShape.approve);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+        const reviewShape = (tools.kompass_pr_sync as any).args.review.unwrap().shape;
+        assert.ok(reviewShape.approve);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 
   test("exposes ticket assignees and comments, and PR assignees", async () => {
-    const tools = await createOpenCodeTools((() => {
-      throw new Error("not implemented");
-    }) as never, createMockClient(), process.cwd());
+    await withTempHome(async () => {
+      const tools = await createOpenCodeTools((() => {
+        throw new Error("not implemented");
+      }) as never, createMockClient() as never, process.cwd());
 
-    const prSyncArgs = (tools.kompass_pr_sync as any).args;
-    const ticketSyncArgs = (tools.kompass_ticket_sync as any).args;
-    assert.ok(prSyncArgs.assignees);
-    assert.ok(ticketSyncArgs.assignees);
-    assert.ok(ticketSyncArgs.comments);
-    assert.equal(ticketSyncArgs.title.isOptional(), true);
+      const prSyncArgs = (tools.kompass_pr_sync as any).args;
+      const ticketSyncArgs = (tools.kompass_ticket_sync as any).args;
+      assert.ok(prSyncArgs.assignees);
+      assert.ok(ticketSyncArgs.assignees);
+      assert.ok(ticketSyncArgs.comments);
+      assert.equal(ticketSyncArgs.title.isOptional(), true);
+    });
+  });
+
+  test("observes slash-command expansion failures without throwing", async () => {
+    await withTempHome(async () => {
+      const client = createMockClient();
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "kompass-tools-bad-config-"));
+
+      try {
+        await mkdir(path.join(tempDir, ".opencode"), { recursive: true });
+        await writeFile(
+          path.join(tempDir, ".opencode", "kompass.jsonc"),
+          `{
+            "shared": {
+              "prApprove": true,
+          }`,
+        );
+
+        const plugin = await OpenCodeCompassPlugin({
+          $: (() => {
+            throw new Error("not implemented");
+          }) as never,
+          client: client as never,
+          directory: tempDir,
+          worktree: tempDir,
+        } as never);
+
+        const output = {
+          args: {
+            prompt: "/review auth bug",
+            command: "/review auth bug",
+          },
+        };
+
+        await plugin["tool.execute.before"]?.(
+          {
+            tool: "task",
+            sessionID: "session-1",
+            callID: "call-1",
+          } as never,
+          output as never,
+        );
+
+        assert.equal(output.args.prompt, "/review auth bug");
+        assert.ok(client.logs.some((entry) => entry.body?.message?.includes("Skipping Kompass tool registration")));
+        assert.ok(client.logs.some((entry) => entry.body?.message?.includes("Failed to expand slash command for task tool")));
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 });


### PR DESCRIPTION
This branch makes Kompass load home-level config as a fallback while still letting project config win, and updates the OpenCode adapter to replace built-in agent and command definitions instead of preserving stale defaults. It also hardens plugin logging paths so command expansion and hook failures are observed without breaking execution.

- load config from the home directory before project overrides and add coverage for fallback and precedence behavior in `packages/core/lib/config.ts` and `packages/core/test/config.test.ts`
- update OpenCode agent and command registration to overwrite existing definitions, with matching tests in `packages/opencode/config.ts`, `packages/opencode/test/agents-config.test.ts`, and `packages/opencode/test/commands-config.test.ts`
- add safer failure logging around slash-command expansion, plugin hooks, and reload disposal in `packages/opencode/index.ts` and `packages/opencode/test/tool-registration.test.ts`
- align related tests with isolated HOME setup in `packages/core/test/commands.test.ts` and `packages/opencode/test/agents-config.test.ts`

Testing was not run in this session.