### PR TITLE
Fix task prompt precedence for slash command expansion

### DIFF
--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -155,10 +155,10 @@ export async function getTaskToolExecution(
 
   let expandedCommand: CommandExecution | undefined;
   try {
-    expandedCommand = command
-      ? await expandSlashCommandPrompt(projectRoot, command, logger)
-      : prompt
-        ? await expandSlashCommandPrompt(projectRoot, prompt, logger)
+    expandedCommand = prompt
+      ? await expandSlashCommandPrompt(projectRoot, prompt, logger)
+      : command
+        ? await expandSlashCommandPrompt(projectRoot, command, logger)
         : undefined;
   } catch (error) {
     if (logger) {

--- a/packages/opencode/test/task-hook.test.ts
+++ b/packages/opencode/test/task-hook.test.ts
@@ -38,6 +38,31 @@ describe("getTaskToolExecution", () => {
     assert.equal(output.args.prompt, execution?.prompt);
   });
 
+  test("prefers the raw prompt over summarized command metadata", async () => {
+    const output = {
+      args: {
+        prompt: "/review auth bug with multiline\nextra context",
+        description: "Run review command",
+        subagent_type: "reviewer",
+        command: "@reviewer /review auth bug",
+      },
+    };
+
+    const execution = await getTaskToolExecution(
+      {
+        tool: "task",
+        sessionID: "session-1",
+        callID: "call-1",
+      },
+      output,
+      process.cwd(),
+    );
+
+    assert.equal(execution?.command_name, "review");
+    assert.equal(execution?.command_arguments, "auth bug with multiline\nextra context");
+    assert.match(execution?.prompt ?? "", /<arguments>\s*auth bug with multiline\nextra context\s*<\/arguments>/);
+  });
+
   test("ignores non-task tool calls", async () => {
     const execution = await getTaskToolExecution(
       {
@@ -100,6 +125,34 @@ describe("getTaskToolExecution", () => {
       description: undefined,
       subagent_type: undefined,
     });
+  });
+
+  test("falls back to command metadata when prompt is missing", async () => {
+    const output = {
+      args: {
+        prompt: undefined,
+        command: "/branch Branch naming guidance: fix login redirect",
+        description: "Create feature branch",
+        subagent_type: "worker",
+      },
+    };
+
+    const execution = await getTaskToolExecution(
+      {
+        tool: "task",
+        sessionID: "session-1",
+        callID: "call-1",
+      },
+      output,
+      process.cwd(),
+    );
+
+    assert.equal(execution?.command, "/branch Branch naming guidance: fix login redirect");
+    assert.equal(execution?.command_name, "branch");
+    assert.equal(execution?.command_arguments, "Branch naming guidance: fix login redirect");
+    assert.match(execution?.prompt ?? "", /## Goal/);
+    assert.match(execution?.prompt ?? "", /<arguments>\s*Branch naming guidance: fix login redirect\s*<\/arguments>/);
+    assert.equal(output.args.prompt, execution?.prompt);
   });
 });
 


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Use the raw task prompt as the primary source for slash command expansion so multiline context is preserved, while still falling back to command metadata when no prompt is present.

## Checklist
### Task prompt parsing
- [x] Prefer the raw task prompt over summarized command metadata when both are present
- [x] Preserve multiline prompt arguments during slash command expansion

### Metadata fallback
- [x] Continue expanding from command metadata when the raw prompt is missing

### Validation
- [x] Verify that task tool calls keep the original prompt context in expanded command prompts
- [x] Confirm that command metadata still expands correctly when no prompt is provided