### PR TITLE
docs: standardize command docs around workflow output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ packages/opencode/.opencode/ # Generated OpenCode output for review
 - Author command definitions in `packages/core/commands/`; treat `packages/opencode/.opencode/commands/` as generated output only
 - Treat `packages/core/commands/index.ts`, `packages/core/lib/config.ts`, `kompass.schema.json`, the bundled `kompass.jsonc` files, and the relevant docs as a linked surface area; if one changes, verify the others still describe the same command set and config shape
 - Use `packages/core/commands/pr/create.md` as the canonical example for command structure and tone
-- Keep this section order in command docs unless a command has a strong reason not to: `## Goal`, `## Workflow`, `## Additional Context`, `## Output`
+- Keep this section order in command docs unless a command has a strong reason not to: `## Goal`, `## Additional Context`, `## Workflow`
+- Keep `### Output` as the final subsection inside `## Workflow`; do not use a separate top-level `## Output` section
 - Start `## Workflow` with a dedicated `### Arguments` subsection that stores the raw `$ARGUMENTS` value inside literal `<arguments>` tags before any normalization
 - Follow `### Arguments` with `### Interpret Arguments`, and normalize `<arguments>` into any additional named placeholders before execution steps
 - Use angle-bracket placeholders consistently for derived values and stored context, such as `<arguments>`, `<base>`, `<additional-context>`, `<pr-url>`, and define each placeholder before it is referenced later in the command
@@ -66,9 +67,9 @@ packages/opencode/.opencode/ # Generated OpenCode output for review
 - Use literal `<dispatch>` tags when the workflow must forward exact text as the next user message to a subagent session; `agent` is required, the block body is the exact rendered message to send, and slash commands belong on the first line of the body when needed
 - Do not use `<task>` blocks in command docs; author navigator delegation with `<dispatch>` blocks only
 - When a command can pause for approval or loop over repeated work, describe the resume condition and the exact cases that must STOP without mutating state
-- Use `## Additional Context` for instructions about how optional guidance, related tickets, focus areas, or other stored context should influence analysis and output
-- Use `## Output` to define the exact user-facing response shape, including placeholders for generated values
-- Make success, blocked, and no-op outcomes explicit in `## Output` or the surrounding workflow so navigator-led flows report deterministic end states
+- Use `## Additional Context` for instructions about how optional guidance, related tickets, focus areas, or other stored context should influence analysis and response formatting
+- Use `### Output` as the final workflow step to define the exact user-facing response shape, including placeholders for generated values
+- Make success, blocked, and no-op outcomes explicit in `### Output` or the surrounding workflow so navigator-led flows report deterministic end states
 - For terminal command outcomes, prefer an explicit final line inside the output block: `No additional steps are required.`
 - For one-off commands that do not orchestrate follow-up work, make every success, blocked, or no-op output explicitly terminal with that final line
 - Command-specific extra sections are fine, but they should support this core structure rather than replace it
@@ -79,6 +80,10 @@ Example command structure:
 ## Goal
 
 Describe the command's purpose in one short paragraph.
+
+## Additional Context
+
+- Explain how optional guidance should influence planning or execution
 
 ## Workflow
 
@@ -122,11 +127,7 @@ Constraints: <additional-context>
 
 - STOP if implementation is blocked or incomplete
 
-## Additional Context
-
-- Explain how optional guidance should influence planning or execution
-
-## Output
+### Output
 
 - Define the exact success, blocked, and no-op response shapes
 - For terminal outcomes, end the output block with `No additional steps are required.`

--- a/packages/core/commands/ask.md
+++ b/packages/core/commands/ask.md
@@ -2,6 +2,11 @@
 
 Answer a question about the current project or codebase using the repository and available context.
 
+## Additional Context
+
+- Use `<additional-context>` to prioritize the most relevant files, subsystems, or concerns
+- Ask only when the question cannot be determined from `<arguments>` and the conversation
+
 ## Workflow
 
 ### Arguments
@@ -29,12 +34,7 @@ $ARGUMENTS
 - Include file references when they materially help the answer
 - Keep the response concise unless the question requires more detail
 
-## Additional Context
-
-- Use `<additional-context>` to prioritize the most relevant files, subsystems, or concerns
-- Ask only when the question cannot be determined from `<arguments>` and the conversation
-
-## Output
+### Output
 
 If the question cannot be determined, display:
 ```

--- a/packages/core/commands/branch.md
+++ b/packages/core/commands/branch.md
@@ -2,6 +2,10 @@
 
 Create and switch to a categorized branch whose name summarizes the current uncommitted work.
 
+## Additional Context
+
+Use `<branch-context>` to steer the branch category and slug while keeping the final name short, descriptive, and aligned with the change type.
+
 ## Workflow
 
 ### Arguments
@@ -36,11 +40,7 @@ $ARGUMENTS
 - If that name already exists, retry once with a short numeric suffix
 - Store the checked-out branch as `<new-branch>`
 
-## Additional Context
-
-Use `<branch-context>` to steer the branch category and slug while keeping the final name short, descriptive, and aligned with the change type.
-
-## Output
+### Output
 
 If there is nothing to branch from, display:
 ```

--- a/packages/core/commands/commit-and-push.md
+++ b/packages/core/commands/commit-and-push.md
@@ -2,6 +2,10 @@
 
 Create a commit and immediately push it to the remote repository.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing changes and writing the commit message.
+
 ## Workflow
 
 ### Arguments
@@ -36,11 +40,7 @@ $ARGUMENTS
 - Store the successful destination as `<push-target>`
 - If push fails, STOP and report the push error
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing changes and writing the commit message.
-
-## Output
+### Output
 
 If there is nothing to commit, display:
 ```

--- a/packages/core/commands/commit.md
+++ b/packages/core/commands/commit.md
@@ -2,6 +2,10 @@
 
 Create a commit with an appropriate message summarizing the uncommitted changes.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing changes and writing the commit message.
+
 ## Workflow
 
 ### Arguments
@@ -29,11 +33,7 @@ $ARGUMENTS
 <%~ include("@commit") %>
 - Store the created commit hash as `<hash>`
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing changes and writing the commit message.
-
-## Output
+### Output
 
 If there is nothing to commit, display:
 ```

--- a/packages/core/commands/dev.md
+++ b/packages/core/commands/dev.md
@@ -2,6 +2,10 @@
 
 Implement a feature or fix based on a ticket or request, then prepare for PR creation.
 
+## Additional Context
+
+Use `<additional-context>` to refine priorities, scope, and tradeoffs while implementing `<request-context>`.
+
 ## Workflow
 
 ### Arguments
@@ -46,11 +50,7 @@ $ARGUMENTS
 - Store the current branch name as `<branch>`
 - Do not create the pull request in this command; stop when the branch is ready for `pr/create`
 
-## Additional Context
-
-Use `<additional-context>` to refine priorities, scope, and tradeoffs while implementing `<request-context>`.
-
-## Output
+### Output
 
 When the implementation is ready for PR creation, display:
 ```

--- a/packages/core/commands/learn.md
+++ b/packages/core/commands/learn.md
@@ -2,6 +2,13 @@
 
 Extract non-obvious learnings from this session and document them appropriately.
 
+## Additional Context
+
+- Document non-obvious discoveries only
+- Skip obvious facts, standard behavior, and already-documented items
+- Avoid verbose explanations and session-specific details
+- Use `<focus-scope>` and `<additional-context>` to decide where to look more closely
+
 ## Workflow
 
 ### Arguments
@@ -57,14 +64,7 @@ $ARGUMENTS
 - Report which files were created or updated and how many learnings were added to each
 - Store those summary lines as `<file-update-lines>` in the format `- <file-path>: <learning-count> learnings`
 
-## Additional Context
-
-- Document non-obvious discoveries only
-- Skip obvious facts, standard behavior, and already-documented items
-- Avoid verbose explanations and session-specific details
-- Use `<focus-scope>` and `<additional-context>` to decide where to look more closely
-
-## Output
+### Output
 
 When the documentation update is complete, display:
 ```

--- a/packages/core/commands/pr/create.md
+++ b/packages/core/commands/pr/create.md
@@ -2,6 +2,15 @@
 
 Create a pull request for the current branch, handling the entire workflow from change detection to PR submission.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing changes and writing the PR description.
+- Always include the `Ticket`, `Description`, and `Checklist` sections in that order.
+- Use the literal `SKIPPED` when ticket mention was skipped.
+- Keep the description focused on intent, not implementation details.
+- Mark checklist validation items as completed if validation was performed.
+- Uncommitted changes and being on the base branch block PR creation entirely.
+
 ## Workflow
 
 ### Arguments
@@ -117,16 +126,7 @@ Use `pr_sync` to create the pull request:
 - If `pr_sync` reports that a PR already exists for the branch, treat the result as an existing PR
 - Track whether the branch was pushed during this run and report that status in the final response
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing changes and writing the PR description.
-- Always include the `Ticket`, `Description`, and `Checklist` sections in that order.
-- Use the literal `SKIPPED` when ticket mention was skipped.
-- Keep the description focused on intent, not implementation details.
-- Mark checklist validation items as completed if validation was performed.
-- Uncommitted changes and being on the base branch block PR creation entirely.
-
-## Output
+### Output
 
 If PR creation stops because there is nothing to include, display:
 ```

--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -2,6 +2,12 @@
 
 Address feedback on a pull request by making fixes and responding to review threads.
 
+## Additional Context
+
+Use `<additional-context>` when prioritizing which review feedback to address first and when deciding how much scope to take on in this pass.
+- Default `/pr/fix` behavior is review-first: show the proposed fix, gather feedback, and loop until the user approves before committing, pushing, or replying on the PR.
+- Treat `/pr/fix auto` as the explicit opt-in to skip the approval loop and proceed directly from passing validation to commit, push, and PR replies.
+
 ## Workflow
 
 ### Arguments
@@ -113,13 +119,7 @@ pr_sync refUrl="<pr-context.pr.url>" commitId="<commit-sha>" review={"comments":
 Confirm which feedback was addressed and which was intentionally not followed.
 - Store the number of resolved threads as `<threads-resolved>`
 
-## Additional Context
-
-Use `<additional-context>` when prioritizing which review feedback to address first and when deciding how much scope to take on in this pass.
-- Default `/pr/fix` behavior is review-first: show the proposed fix, gather feedback, and loop until the user approves before committing, pushing, or replying on the PR.
-- Treat `/pr/fix auto` as the explicit opt-in to skip the approval loop and proceed directly from passing validation to commit, push, and PR replies.
-
-## Output
+### Output
 
 When waiting for approval or revision feedback, display:
 ```

--- a/packages/core/commands/pr/review.md
+++ b/packages/core/commands/pr/review.md
@@ -2,6 +2,10 @@
 
 Review a GitHub pull request and publish findings as a formal review with inline comments.
 
+## Additional Context
+
+Use `<ticket-context>` and `<additional-context>` to judge whether the PR meets its stated intent without over-indexing on stylistic preferences.
+
 ## Workflow
 
 ### Arguments
@@ -95,11 +99,8 @@ For multi-line: add `startLine`. For deleted lines: use `side: "LEFT"`.
 
 If `pr_sync` returns a review URL, store it as `<review-url>`.
 
-## Additional Context
+### Output
 
-Use `<ticket-context>` and `<additional-context>` to judge whether the PR meets its stated intent without over-indexing on stylistic preferences.
-
-## Output
 <% if (it.config.shared.prApprove === true) { -%>
 When approved:
 ```

--- a/packages/core/commands/review.md
+++ b/packages/core/commands/review.md
@@ -2,6 +2,10 @@
 
 Review code changes and provide actionable feedback with a grade and risk assessment.
 
+## Additional Context
+
+Use `<additional-context>` to prioritize specific risks, feature areas, or related concerns while reviewing `<changes>`.
+
 ## Workflow
 
 ### Arguments
@@ -49,11 +53,7 @@ While reading files:
 - For deleted files, inspect prior contents from git because `changes_load` does not provide full deleted-file contents
 - Use a helper agent only if the changed-file set is too large to review comfortably in one session after the changed paths are already known
 
-## Additional Context
-
-Use `<additional-context>` to prioritize specific risks, feature areas, or related concerns while reviewing `<changes>`.
-
-## Output
+### Output
 
 When the review is complete, display:
 ```

--- a/packages/core/commands/rmslop.md
+++ b/packages/core/commands/rmslop.md
@@ -2,6 +2,10 @@
 
 Remove AI-generated code slop and inconsistencies from the branch changes.
 
+## Additional Context
+
+Use `<additional-context>` to decide which kinds of slop to prioritize and which areas should remain untouched.
+
 ## Workflow
 
 ### Arguments
@@ -61,11 +65,7 @@ $ARGUMENTS
 - Create a focused commit describing the cleanup
 - Store the created commit hash as `<hash>`
 
-## Additional Context
-
-Use `<additional-context>` to decide which kinds of slop to prioritize and which areas should remain untouched.
-
-## Output
+### Output
 
 If there is no branch work to clean up, display:
 ```

--- a/packages/core/commands/ship.md
+++ b/packages/core/commands/ship.md
@@ -2,6 +2,10 @@
 
 Ship the current work by delegating branch creation, commit creation, and PR creation.
 
+## Additional Context
+
+Use `<branch-context>` to steer delegated branch naming. Use `<additional-context>` to refine the delegated commit and PR summaries. Pass `<base>` through to PR creation when it was provided.
+
 ## Workflow
 
 ### Arguments
@@ -56,11 +60,7 @@ Additional context: <additional-context>
 - If `<pr-result>` says there is nothing to include in a PR, STOP and report that there is nothing to ship
 - Otherwise, continue with the created or existing PR
 
-## Additional Context
-
-Use `<branch-context>` to steer delegated branch naming. Use `<additional-context>` to refine the delegated commit and PR summaries. Pass `<base>` through to PR creation when it was provided.
-
-## Output
+### Output
 
 If there is nothing to ship, display:
 ```

--- a/packages/core/commands/ticket/ask.md
+++ b/packages/core/commands/ticket/ask.md
@@ -2,6 +2,12 @@
 
 Load a ticket and its discussion, answer the user's question, and post that answer back to the ticket.
 
+## Additional Context
+
+- Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
+- Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
+- Ask only when the ticket source or question cannot be determined reliably
+
 ## Workflow
 
 ### Arguments
@@ -35,13 +41,7 @@ $ARGUMENTS
   - `comments: [<ticket-answer>]`
 - Store the returned ticket URL as `<ticket-url>`
 
-## Additional Context
-
-- Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
-- Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
-- Ask only when the ticket source or question cannot be determined reliably
-
-## Output
+### Output
 
 If the ticket context or question cannot be determined, display:
 ```

--- a/packages/core/commands/ticket/create.md
+++ b/packages/core/commands/ticket/create.md
@@ -2,6 +2,10 @@
 
 Create a ticket that summarizes the work returned by the current change comparison.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing the work and writing the ticket title and body.
+
 ## Workflow
 
 ### Arguments
@@ -36,11 +40,7 @@ Use `ticket_sync` with `refUrl` unset to create the ticket:
 - Store the generated title as `<ticket-title>`
 - Store the created issue URL as `<ticket-url>`
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing the work and writing the ticket title and body.
-
-## Output
+### Output
 
 If there is no work to summarize, display:
 ```

--- a/packages/core/commands/ticket/dev.md
+++ b/packages/core/commands/ticket/dev.md
@@ -2,6 +2,10 @@
 
 Implement a ticket by orchestrating development, branching, commit-and-push, and PR creation.
 
+## Additional Context
+
+Use `<additional-context>` to refine scope, sequencing, and tradeoffs across the delegated `/dev`, `/branch`, `/commit-and-push`, and `/pr/create` steps.
+
 ## Workflow
 
 ### Arguments
@@ -83,11 +87,7 @@ Additional context: <additional-context>
 - If `<pr-result>` is blocked or incomplete, STOP and report the PR blocker
 - Otherwise, continue and store the resulting PR URL as `<pr-url>`
 
-## Additional Context
-
-Use `<additional-context>` to refine scope, sequencing, and tradeoffs across the delegated `/dev`, `/branch`, `/commit-and-push`, and `/pr/create` steps.
-
-## Output
+### Output
 
 When the ticket work is complete, display:
 ```

--- a/packages/core/commands/ticket/plan-and-sync.md
+++ b/packages/core/commands/ticket/plan-and-sync.md
@@ -2,6 +2,18 @@
 
 Create a scoped implementation plan from a request or ticket, then capture that plan in the relevant ticket flow without losing important technical context.
 
+## Additional Context
+
+- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
+- Use the current request to determine `<planning-objective>`.
+- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
+- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
+- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
+- If technical details provided in the conversation are good, keep them.
+- If those details are incomplete, validate and improve them.
+- For existing tickets, update the same ticket instead of creating a replacement.
+- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
+
 ## Workflow
 
 ### Arguments
@@ -70,19 +82,7 @@ $ARGUMENTS
 - Return the generated title, a brief plan summary, and the ticket reference or URL
 - Call out assumptions, risks, or blockers only when they materially matter
 
-## Additional Context
-
-- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
-- Use the current request to determine `<planning-objective>`.
-- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
-- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
-- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
-- If technical details provided in the conversation are good, keep them.
-- If those details are incomplete, validate and improve them.
-- For existing tickets, update the same ticket instead of creating a replacement.
-- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
-
-## Output
+### Output
 
 If planning context cannot be determined, display:
 ```

--- a/packages/core/commands/ticket/plan.md
+++ b/packages/core/commands/ticket/plan.md
@@ -2,6 +2,18 @@
 
 Create a scoped implementation plan from a request or ticket and present it directly without modifying any ticket state.
 
+## Additional Context
+
+- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
+- Use the current request to determine `<planning-objective>`.
+- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
+- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
+- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
+- If technical details provided in the conversation are good, keep them.
+- If those details are incomplete, validate and improve them.
+- If a ticket source was provided, use it as planning context only; do not sync updates back automatically.
+- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
+
 ## Workflow
 
 ### Arguments
@@ -58,19 +70,7 @@ $ARGUMENTS
 - Return the generated title and plan details without creating or updating a ticket
 - Call out assumptions, risks, or blockers only when they materially matter
 
-## Additional Context
-
-- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
-- Use the current request to determine `<planning-objective>`.
-- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
-- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
-- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
-- If technical details provided in the conversation are good, keep them.
-- If those details are incomplete, validate and improve them.
-- If a ticket source was provided, use it as planning context only; do not sync updates back automatically.
-- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
-
-## Output
+### Output
 
 If planning context cannot be determined, display:
 ```

--- a/packages/core/commands/todo.md
+++ b/packages/core/commands/todo.md
@@ -2,6 +2,13 @@
 
 Work through a todo file one pending item at a time by planning, getting approval, implementing, committing, and marking completed tasks.
 
+## Additional Context
+
+- Keep the loop focused on one checklist item at a time
+- Do not merge separate todo items unless the file explicitly frames them as one task
+- If implementation reveals scope that materially changes the approved plan, pause and re-plan before marking the task complete
+- Use `<additional-context>` to prioritize tradeoffs, constraints, or validation expectations during planning and implementation
+
 ## Workflow
 
 ### Arguments
@@ -100,14 +107,7 @@ Additional context: <additional-context>
 - Save the updated todo file
 - Return to `### Load Todo Context` and repeat the workflow for the next pending task
 
-## Additional Context
-
-- Keep the loop focused on one checklist item at a time
-- Do not merge separate todo items unless the file explicitly frames them as one task
-- If implementation reveals scope that materially changes the approved plan, pause and re-plan before marking the task complete
-- Use `<additional-context>` to prioritize tradeoffs, constraints, or validation expectations during planning and implementation
-
-## Output
+### Output
 
 When presenting a task plan for approval, display:
 ```

--- a/packages/opencode/.opencode/commands/ask.md
+++ b/packages/opencode/.opencode/commands/ask.md
@@ -7,6 +7,11 @@ agent: build
 
 Answer a question about the current project or codebase using the repository and available context.
 
+## Additional Context
+
+- Use `<additional-context>` to prioritize the most relevant files, subsystems, or concerns
+- Ask only when the question cannot be determined from `<arguments>` and the conversation
+
 ## Workflow
 
 ### Arguments
@@ -34,12 +39,7 @@ $ARGUMENTS
 - Include file references when they materially help the answer
 - Keep the response concise unless the question requires more detail
 
-## Additional Context
-
-- Use `<additional-context>` to prioritize the most relevant files, subsystems, or concerns
-- Ask only when the question cannot be determined from `<arguments>` and the conversation
-
-## Output
+### Output
 
 If the question cannot be determined, display:
 ```

--- a/packages/opencode/.opencode/commands/branch.md
+++ b/packages/opencode/.opencode/commands/branch.md
@@ -7,6 +7,10 @@ agent: build
 
 Create and switch to a categorized branch whose name summarizes the current uncommitted work.
 
+## Additional Context
+
+Use `<branch-context>` to steer the branch category and slug while keeping the final name short, descriptive, and aligned with the change type.
+
 ## Workflow
 
 ### Arguments
@@ -54,11 +58,7 @@ $ARGUMENTS
 - If that name already exists, retry once with a short numeric suffix
 - Store the checked-out branch as `<new-branch>`
 
-## Additional Context
-
-Use `<branch-context>` to steer the branch category and slug while keeping the final name short, descriptive, and aligned with the change type.
-
-## Output
+### Output
 
 If there is nothing to branch from, display:
 ```

--- a/packages/opencode/.opencode/commands/commit-and-push.md
+++ b/packages/opencode/.opencode/commands/commit-and-push.md
@@ -7,6 +7,10 @@ agent: build
 
 Create a commit and immediately push it to the remote repository.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing changes and writing the commit message.
+
 ## Workflow
 
 ### Arguments
@@ -77,11 +81,7 @@ type: summary
 - Store the successful destination as `<push-target>`
 - If push fails, STOP and report the push error
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing changes and writing the commit message.
-
-## Output
+### Output
 
 If there is nothing to commit, display:
 ```

--- a/packages/opencode/.opencode/commands/commit.md
+++ b/packages/opencode/.opencode/commands/commit.md
@@ -7,6 +7,10 @@ agent: build
 
 Create a commit with an appropriate message summarizing the uncommitted changes.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing changes and writing the commit message.
+
 ## Workflow
 
 ### Arguments
@@ -70,11 +74,7 @@ type: summary
 7. Only run `git status` if the commit fails and needs diagnosis
 - Store the created commit hash as `<hash>`
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing changes and writing the commit message.
-
-## Output
+### Output
 
 If there is nothing to commit, display:
 ```

--- a/packages/opencode/.opencode/commands/dev.md
+++ b/packages/opencode/.opencode/commands/dev.md
@@ -7,6 +7,10 @@ agent: navigator
 
 Implement a feature or fix based on a ticket or request, then prepare for PR creation.
 
+## Additional Context
+
+Use `<additional-context>` to refine priorities, scope, and tradeoffs while implementing `<request-context>`.
+
 ## Workflow
 
 ### Arguments
@@ -60,11 +64,7 @@ $ARGUMENTS
 - Store the current branch name as `<branch>`
 - Do not create the pull request in this command; stop when the branch is ready for `pr/create`
 
-## Additional Context
-
-Use `<additional-context>` to refine priorities, scope, and tradeoffs while implementing `<request-context>`.
-
-## Output
+### Output
 
 When the implementation is ready for PR creation, display:
 ```

--- a/packages/opencode/.opencode/commands/learn.md
+++ b/packages/opencode/.opencode/commands/learn.md
@@ -7,6 +7,13 @@ agent: build
 
 Extract non-obvious learnings from this session and document them appropriately.
 
+## Additional Context
+
+- Document non-obvious discoveries only
+- Skip obvious facts, standard behavior, and already-documented items
+- Avoid verbose explanations and session-specific details
+- Use `<focus-scope>` and `<additional-context>` to decide where to look more closely
+
 ## Workflow
 
 ### Arguments
@@ -62,14 +69,7 @@ $ARGUMENTS
 - Report which files were created or updated and how many learnings were added to each
 - Store those summary lines as `<file-update-lines>` in the format `- <file-path>: <learning-count> learnings`
 
-## Additional Context
-
-- Document non-obvious discoveries only
-- Skip obvious facts, standard behavior, and already-documented items
-- Avoid verbose explanations and session-specific details
-- Use `<focus-scope>` and `<additional-context>` to decide where to look more closely
-
-## Output
+### Output
 
 When the documentation update is complete, display:
 ```

--- a/packages/opencode/.opencode/commands/pr/create.md
+++ b/packages/opencode/.opencode/commands/pr/create.md
@@ -7,6 +7,15 @@ agent: build
 
 Create a pull request for the current branch, handling the entire workflow from change detection to PR submission.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing changes and writing the PR description.
+- Always include the `Ticket`, `Description`, and `Checklist` sections in that order.
+- Use the literal `SKIPPED` when ticket mention was skipped.
+- Keep the description focused on intent, not implementation details.
+- Mark checklist validation items as completed if validation was performed.
+- Uncommitted changes and being on the base branch block PR creation entirely.
+
 ## Workflow
 
 ### Arguments
@@ -153,16 +162,7 @@ Use `kompass_pr_sync` to create the pull request:
 - If `kompass_pr_sync` reports that a PR already exists for the branch, treat the result as an existing PR
 - Track whether the branch was pushed during this run and report that status in the final response
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing changes and writing the PR description.
-- Always include the `Ticket`, `Description`, and `Checklist` sections in that order.
-- Use the literal `SKIPPED` when ticket mention was skipped.
-- Keep the description focused on intent, not implementation details.
-- Mark checklist validation items as completed if validation was performed.
-- Uncommitted changes and being on the base branch block PR creation entirely.
-
-## Output
+### Output
 
 If PR creation stops because there is nothing to include, display:
 ```

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -7,6 +7,12 @@ agent: build
 
 Address feedback on a pull request by making fixes and responding to review threads.
 
+## Additional Context
+
+Use `<additional-context>` when prioritizing which review feedback to address first and when deciding how much scope to take on in this pass.
+- Default `/pr/fix` behavior is review-first: show the proposed fix, gather feedback, and loop until the user approves before committing, pushing, or replying on the PR.
+- Treat `/pr/fix auto` as the explicit opt-in to skip the approval loop and proceed directly from passing validation to commit, push, and PR replies.
+
 ## Workflow
 
 ### Arguments
@@ -124,13 +130,7 @@ kompass_pr_sync refUrl="<pr-context.pr.url>" commitId="<commit-sha>" review={"co
 Confirm which feedback was addressed and which was intentionally not followed.
 - Store the number of resolved threads as `<threads-resolved>`
 
-## Additional Context
-
-Use `<additional-context>` when prioritizing which review feedback to address first and when deciding how much scope to take on in this pass.
-- Default `/pr/fix` behavior is review-first: show the proposed fix, gather feedback, and loop until the user approves before committing, pushing, or replying on the PR.
-- Treat `/pr/fix auto` as the explicit opt-in to skip the approval loop and proceed directly from passing validation to commit, push, and PR replies.
-
-## Output
+### Output
 
 When waiting for approval or revision feedback, display:
 ```

--- a/packages/opencode/.opencode/commands/pr/review.md
+++ b/packages/opencode/.opencode/commands/pr/review.md
@@ -7,6 +7,10 @@ agent: reviewer
 
 Review a GitHub pull request and publish findings as a formal review with inline comments.
 
+## Additional Context
+
+Use `<ticket-context>` and `<additional-context>` to judge whether the PR meets its stated intent without over-indexing on stylistic preferences.
+
 ## Workflow
 
 ### Arguments
@@ -100,11 +104,8 @@ For multi-line: add `startLine`. For deleted lines: use `side: "LEFT"`.
 
 If `kompass_pr_sync` returns a review URL, store it as `<review-url>`.
 
-## Additional Context
+### Output
 
-Use `<ticket-context>` and `<additional-context>` to judge whether the PR meets its stated intent without over-indexing on stylistic preferences.
-
-## Output
 When approved:
 ```
 PR approved for #<pr-context.pr.number>

--- a/packages/opencode/.opencode/commands/review.md
+++ b/packages/opencode/.opencode/commands/review.md
@@ -7,6 +7,10 @@ agent: reviewer
 
 Review code changes and provide actionable feedback with a grade and risk assessment.
 
+## Additional Context
+
+Use `<additional-context>` to prioritize specific risks, feature areas, or related concerns while reviewing `<changes>`.
+
 ## Workflow
 
 ### Arguments
@@ -54,11 +58,7 @@ While reading files:
 - For deleted files, inspect prior contents from git because `kompass_changes_load` does not provide full deleted-file contents
 - Use a helper agent only if the changed-file set is too large to review comfortably in one session after the changed paths are already known
 
-## Additional Context
-
-Use `<additional-context>` to prioritize specific risks, feature areas, or related concerns while reviewing `<changes>`.
-
-## Output
+### Output
 
 When the review is complete, display:
 ```

--- a/packages/opencode/.opencode/commands/rmslop.md
+++ b/packages/opencode/.opencode/commands/rmslop.md
@@ -7,6 +7,10 @@ agent: build
 
 Remove AI-generated code slop and inconsistencies from the branch changes.
 
+## Additional Context
+
+Use `<additional-context>` to decide which kinds of slop to prioritize and which areas should remain untouched.
+
 ## Workflow
 
 ### Arguments
@@ -65,11 +69,7 @@ $ARGUMENTS
 - Create a focused commit describing the cleanup
 - Store the created commit hash as `<hash>`
 
-## Additional Context
-
-Use `<additional-context>` to decide which kinds of slop to prioritize and which areas should remain untouched.
-
-## Output
+### Output
 
 If there is no branch work to clean up, display:
 ```

--- a/packages/opencode/.opencode/commands/ship.md
+++ b/packages/opencode/.opencode/commands/ship.md
@@ -7,6 +7,10 @@ agent: navigator
 
 Ship the current work by delegating branch creation, commit creation, and PR creation.
 
+## Additional Context
+
+Use `<branch-context>` to steer delegated branch naming. Use `<additional-context>` to refine the delegated commit and PR summaries. Pass `<base>` through to PR creation when it was provided.
+
 ## Workflow
 
 ### Arguments
@@ -61,11 +65,7 @@ Additional context: <additional-context>
 - If `<pr-result>` says there is nothing to include in a PR, STOP and report that there is nothing to ship
 - Otherwise, continue with the created or existing PR
 
-## Additional Context
-
-Use `<branch-context>` to steer delegated branch naming. Use `<additional-context>` to refine the delegated commit and PR summaries. Pass `<base>` through to PR creation when it was provided.
-
-## Output
+### Output
 
 If there is nothing to ship, display:
 ```

--- a/packages/opencode/.opencode/commands/ticket/ask.md
+++ b/packages/opencode/.opencode/commands/ticket/ask.md
@@ -7,6 +7,12 @@ agent: build
 
 Load a ticket and its discussion, answer the user's question, and post that answer back to the ticket.
 
+## Additional Context
+
+- Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
+- Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
+- Ask only when the ticket source or question cannot be determined reliably
+
 ## Workflow
 
 ### Arguments
@@ -44,13 +50,7 @@ $ARGUMENTS
   - `comments: [<ticket-answer>]`
 - Store the returned ticket URL as `<ticket-url>`
 
-## Additional Context
-
-- Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
-- Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
-- Ask only when the ticket source or question cannot be determined reliably
-
-## Output
+### Output
 
 If the ticket context or question cannot be determined, display:
 ```

--- a/packages/opencode/.opencode/commands/ticket/create.md
+++ b/packages/opencode/.opencode/commands/ticket/create.md
@@ -7,6 +7,10 @@ agent: build
 
 Create a ticket that summarizes the work returned by the current change comparison.
 
+## Additional Context
+
+Consider `<additional-context>` when analyzing the work and writing the ticket title and body.
+
 ## Workflow
 
 ### Arguments
@@ -71,11 +75,7 @@ Use `kompass_ticket_sync` with `refUrl` unset to create the ticket:
 - Store the generated title as `<ticket-title>`
 - Store the created issue URL as `<ticket-url>`
 
-## Additional Context
-
-Consider `<additional-context>` when analyzing the work and writing the ticket title and body.
-
-## Output
+### Output
 
 If there is no work to summarize, display:
 ```

--- a/packages/opencode/.opencode/commands/ticket/dev.md
+++ b/packages/opencode/.opencode/commands/ticket/dev.md
@@ -7,6 +7,10 @@ agent: build
 
 Implement a ticket by orchestrating development, branching, commit-and-push, and PR creation.
 
+## Additional Context
+
+Use `<additional-context>` to refine scope, sequencing, and tradeoffs across the delegated `/dev`, `/branch`, `/commit-and-push`, and `/pr/create` steps.
+
 ## Workflow
 
 ### Arguments
@@ -98,11 +102,7 @@ Additional context: <additional-context>
 - If `<pr-result>` is blocked or incomplete, STOP and report the PR blocker
 - Otherwise, continue and store the resulting PR URL as `<pr-url>`
 
-## Additional Context
-
-Use `<additional-context>` to refine scope, sequencing, and tradeoffs across the delegated `/dev`, `/branch`, `/commit-and-push`, and `/pr/create` steps.
-
-## Output
+### Output
 
 When the ticket work is complete, display:
 ```

--- a/packages/opencode/.opencode/commands/ticket/plan-and-sync.md
+++ b/packages/opencode/.opencode/commands/ticket/plan-and-sync.md
@@ -7,6 +7,18 @@ agent: planner
 
 Create a scoped implementation plan from a request or ticket, then capture that plan in the relevant ticket flow without losing important technical context.
 
+## Additional Context
+
+- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
+- Use the current request to determine `<planning-objective>`.
+- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
+- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
+- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
+- If technical details provided in the conversation are good, keep them.
+- If those details are incomplete, validate and improve them.
+- For existing tickets, update the same ticket instead of creating a replacement.
+- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
+
 ## Workflow
 
 ### Arguments
@@ -79,19 +91,7 @@ $ARGUMENTS
 - Return the generated title, a brief plan summary, and the ticket reference or URL
 - Call out assumptions, risks, or blockers only when they materially matter
 
-## Additional Context
-
-- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
-- Use the current request to determine `<planning-objective>`.
-- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
-- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
-- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
-- If technical details provided in the conversation are good, keep them.
-- If those details are incomplete, validate and improve them.
-- For existing tickets, update the same ticket instead of creating a replacement.
-- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
-
-## Output
+### Output
 
 If planning context cannot be determined, display:
 ```

--- a/packages/opencode/.opencode/commands/ticket/plan.md
+++ b/packages/opencode/.opencode/commands/ticket/plan.md
@@ -7,6 +7,18 @@ agent: planner
 
 Create a scoped implementation plan from a request or ticket and present it directly without modifying any ticket state.
 
+## Additional Context
+
+- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
+- Use the current request to determine `<planning-objective>`.
+- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
+- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
+- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
+- If technical details provided in the conversation are good, keep them.
+- If those details are incomplete, validate and improve them.
+- If a ticket source was provided, use it as planning context only; do not sync updates back automatically.
+- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
+
 ## Workflow
 
 ### Arguments
@@ -67,19 +79,7 @@ $ARGUMENTS
 - Return the generated title and plan details without creating or updating a ticket
 - Call out assumptions, risks, or blockers only when they materially matter
 
-## Additional Context
-
-- Treat ticket systems generically. Do not assume GitHub or any specific provider unless the provided context makes it relevant.
-- Use the current request to determine `<planning-objective>`.
-- Earlier comments remain in force when they add operative constraints, business rules, technical decisions, migration rules, exact labels or renames, ordering rules, or scoping rules.
-- Use `<additional-context>` to emphasize the most important constraints, dependencies, or focus areas.
-- For technical tickets, repo inspection is expected unless the request is clearly non-technical or repository context is unavailable.
-- If technical details provided in the conversation are good, keep them.
-- If those details are incomplete, validate and improve them.
-- If a ticket source was provided, use it as planning context only; do not sync updates back automatically.
-- Ask only when blocked by a missing or invalid ticket source, or by ambiguity that prevents a reliable plan.
-
-## Output
+### Output
 
 If planning context cannot be determined, display:
 ```

--- a/packages/opencode/.opencode/commands/todo.md
+++ b/packages/opencode/.opencode/commands/todo.md
@@ -7,6 +7,13 @@ agent: navigator
 
 Work through a todo file one pending item at a time by planning, getting approval, implementing, committing, and marking completed tasks.
 
+## Additional Context
+
+- Keep the loop focused on one checklist item at a time
+- Do not merge separate todo items unless the file explicitly frames them as one task
+- If implementation reveals scope that materially changes the approved plan, pause and re-plan before marking the task complete
+- Use `<additional-context>` to prioritize tradeoffs, constraints, or validation expectations during planning and implementation
+
 ## Workflow
 
 ### Arguments
@@ -105,14 +112,7 @@ Additional context: <additional-context>
 - Save the updated todo file
 - Return to `### Load Todo Context` and repeat the workflow for the next pending task
 
-## Additional Context
-
-- Keep the loop focused on one checklist item at a time
-- Do not merge separate todo items unless the file explicitly frames them as one task
-- If implementation reveals scope that materially changes the approved plan, pause and re-plan before marking the task complete
-- Use `<additional-context>` to prioritize tradeoffs, constraints, or validation expectations during planning and implementation
-
-## Output
+### Output
 
 When presenting a task plan for approval, display:
 ```


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Align command templates and guidance around treating output as the final workflow subsection so command structure stays consistent across authored and generated docs.

## Checklist
### Command authoring guidance
- [x] Update repository guidance to make `## Additional Context` precede `## Workflow`
- [x] Clarify that `### Output` belongs at the end of the workflow instead of as a top-level section

### Bundled command docs
- [x] Move command docs in `packages/core/commands/` to the new structure
- [x] Keep response-format guidance aligned with the revised section ordering

### Generated OpenCode docs
- [x] Mirror the same structure updates in `packages/opencode/.opencode/commands/`
- [x] Preserve the generated command content while updating section placement

### Validation
- [x] Verify command docs consistently use `## Goal`, `## Additional Context`, and `## Workflow`
- [x] Check that each updated command ends with `### Output` inside `## Workflow`