### PR TITLE
fix: preserve configured skill paths when bundled skills are unavailable

### DIFF
--- a/packages/opencode/config.ts
+++ b/packages/opencode/config.ts
@@ -49,23 +49,20 @@ async function hasBundledSkillDirectories(root: string): Promise<boolean> {
 }
 
 async function resolveBundledSkillsRoot(): Promise<string | undefined> {
-  let firstExistingCandidate: string | undefined;
-
   for (const candidate of BUNDLED_SKILL_ROOT_CANDIDATES) {
     if (!await pathExists(candidate)) continue;
-
-    firstExistingCandidate ??= candidate;
 
     if (await hasBundledSkillDirectories(candidate)) {
       return candidate;
     }
   }
 
-  return firstExistingCandidate;
+  return undefined;
 }
 
 type ApplyConfigOptions = {
   logger?: PluginLogger;
+  resolveBundledSkillsRoot?: () => Promise<string | undefined>;
 };
 
 function normalizeSkillPaths(paths: unknown): string[] {
@@ -145,23 +142,28 @@ export async function applyCommandsConfig(
 }
 
 export async function applySkillsConfig(cfg: Config, options?: ApplyConfigOptions) {
-  const bundledSkillsRoot = await resolveBundledSkillsRoot();
+  const bundledSkillsRoot = options?.resolveBundledSkillsRoot
+    ? await options.resolveBundledSkillsRoot()
+    : await resolveBundledSkillsRoot();
+  const skillsConfig = cfg as ConfigWithSkillsPaths;
+  const normalizedPaths = normalizeSkillPaths(skillsConfig.skills?.paths);
 
   if (!bundledSkillsRoot) {
     await options?.logger?.warn("Skipping Kompass skills registration", {
       reason: "No bundled skills directory found",
     });
 
-    const skillsConfig = cfg as ConfigWithSkillsPaths;
-    if (skillsConfig.skills && "paths" in skillsConfig.skills) {
+    if (normalizedPaths.length > 0) {
+      skillsConfig.skills ??= {};
+      skillsConfig.skills.paths = normalizedPaths;
+    } else if (skillsConfig.skills && "paths" in skillsConfig.skills) {
       delete skillsConfig.skills.paths;
     }
     return;
   }
 
-  const skillsConfig = cfg as ConfigWithSkillsPaths;
   skillsConfig.skills ??= {};
-  skillsConfig.skills.paths = normalizeSkillPaths(skillsConfig.skills.paths);
+  skillsConfig.skills.paths = normalizedPaths;
 
   if (!skillsConfig.skills.paths.includes(bundledSkillsRoot)) {
     skillsConfig.skills.paths.push(bundledSkillsRoot);

--- a/packages/opencode/test/skills-config.test.ts
+++ b/packages/opencode/test/skills-config.test.ts
@@ -42,4 +42,18 @@ describe("applySkillsConfig", () => {
     assert.equal(cfg.skills?.paths?.length, 2);
     assert.equal(typeof cfg.skills?.paths?.[1], "string");
   });
+
+  test("preserves valid configured skill paths when no bundled skills root exists", async () => {
+    const cfg: { skills?: { paths?: unknown[] } } = {
+      skills: {
+        paths: [undefined, "", "/tmp/custom-skills"],
+      },
+    };
+
+    await applySkillsConfig(cfg as never, {
+      resolveBundledSkillsRoot: async () => undefined,
+    });
+
+    assert.deepEqual(cfg.skills?.paths, ["/tmp/custom-skills"]);
+  });
 });


### PR DESCRIPTION
## Summary
- keep user-configured skill paths intact when no bundled skills root can be resolved
- normalize configured skill paths before fallback handling so valid custom entries remain registered
- add regression coverage for the missing bundled-skills case