### PR TITLE
Fix OpenCode package plugin entry export

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -3,9 +3,9 @@
   "version": "0.9.0",
   "description": "OpenCode plugin for navigating repos with fewer wrong turns",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/plugin.js",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/plugin.js"
   },
   "files": [
     "agents",

--- a/packages/opencode/plugin.ts
+++ b/packages/opencode/plugin.ts
@@ -1,0 +1,1 @@
+export { OpenCodeCompassPlugin, OpenCodeCompassPlugin as default } from "./index.ts";

--- a/packages/opencode/scripts/build.ts
+++ b/packages/opencode/scripts/build.ts
@@ -16,7 +16,7 @@ const runtimeDirs = ["agents", "commands", "components"] as const;
 const bundleExternals = ["@opencode-ai/plugin", "@opencode-ai/plugin/tool"] as const;
 const bundleArgs = [
   "build",
-  "./index.ts",
+  "./plugin.ts",
   "--outdir",
   "./dist",
   "--target",

--- a/packages/opencode/test/plugin-entry.test.ts
+++ b/packages/opencode/test/plugin-entry.test.ts
@@ -1,0 +1,14 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+describe("plugin entry", () => {
+  test("only exposes plugin factories", async () => {
+    const mod = await import("../plugin.ts");
+
+    assert.deepEqual(
+      Object.keys(mod).sort(),
+      ["OpenCodeCompassPlugin", "default"],
+    );
+    assert.equal(mod.default, mod.OpenCodeCompassPlugin);
+  });
+});


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Align the published OpenCode package entry with the plugin bundle so consumers import the intended plugin surface.

## Checklist
### Plugin packaging
- [x] Point the package entry fields at the dedicated plugin bundle
- [x] Build the package from the plugin entry file instead of the broader index entry

### Export surface
- [x] Add a focused plugin entry that only re-exports the plugin factory surface
- [x] Cover the package entry contract with a regression test

### Validation
- [x] Verify that importing the published package only exposes plugin factories
- [x] Check that the package build emits the plugin bundle at the expected entry path