### PR TITLE
fix: mark delegated session commands as synthetic

### DIFF
--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -88,7 +88,8 @@ async function executeSessionCommand(
     query: { directory: context.directory },
     body: {
       ...(sessionCommand.agent ? { agent: sessionCommand.agent } : {}),
-      parts: [{ type: "text", text: sessionCommand.prompt }],
+      // Queue the delegated turn without surfacing the prompt as a normal user message.
+      parts: [{ type: "text", text: sessionCommand.prompt, synthetic: true }],
     },
   });
 

--- a/packages/opencode/test/tool-registration.test.ts
+++ b/packages/opencode/test/tool-registration.test.ts
@@ -294,7 +294,7 @@ describe("createOpenCodeTools", () => {
         query: { directory: process.cwd() },
         body: {
           agent: "reviewer",
-          parts: [{ type: "text", text: result.prompt }],
+          parts: [{ type: "text", text: result.prompt, synthetic: true }],
         },
       });
       assert.equal(client.sessionPrompts.length, 0);


### PR DESCRIPTION
## Summary

Fixes an issue where delegated session commands were not being marked as synthetic, causing them to surface as user messages instead of being handled internally.

## Changes

- Add `synthetic: true` to session command parts to prevent them from surfacing as user messages
- Update `executeSessionCommand` to mark delegated turns as synthetic
- Update test to expect synthetic flag in parts