### PR TITLE
fix: handle detached HEAD in PR workflows

### DIFF
--- a/.github/workflows/kompass-pr-review.yml
+++ b/.github/workflows/kompass-pr-review.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.token.outputs.token }}
+          ref: ${{ github.head_ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -31,11 +31,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- If `<current-branch>` differs from `<pr-branch>`:
+- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>`
+- Otherwise, if `<current-branch>` is unavailable and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<pr-branch>` as `<active-branch>` because the repository is already aligned to the PR head in detached `HEAD` mode
+- Otherwise:
+  - Run `git fetch origin <pr-branch>` to ensure the branch is available locally before checkout
   - Checkout `<pr-branch>` before analyzing repository files or making code changes for this PR
   - After checkout, store the active branch as `<active-branch>`
   - If checkout fails, STOP and report that the PR branch could not be checked out locally
-- Otherwise, store `<current-branch>` as `<active-branch>`
 - Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`
 
 ### Analyze Feedback

--- a/packages/core/commands/pr/review.md
+++ b/packages/core/commands/pr/review.md
@@ -27,11 +27,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- If `<current-branch>` differs from `<pr-branch>`:
+- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>`
+- Otherwise, if `<current-branch>` is unavailable and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<pr-branch>` as `<active-branch>` because the repository is already aligned to the PR head in detached `HEAD` mode
+- Otherwise:
+  - Run `git fetch origin <pr-branch>` to ensure the branch is available locally before checkout
   - Checkout `<pr-branch>` before inspecting local repository files for this PR review
   - After checkout, store the active branch as `<active-branch>`
   - If checkout fails, STOP and report that the PR branch could not be checked out locally
-- Otherwise, store `<current-branch>` as `<active-branch>`
 - Do not inspect local repository code for this PR until `<active-branch>` equals `<pr-branch>`
 
 ### Load Ticket Context

--- a/packages/core/components/load-pr.md
+++ b/packages/core/components/load-pr.md
@@ -5,6 +5,7 @@
 - Store the result as `<%= it.result %>`
 - Store the PR head branch as `<pr-branch>` from `<%= it.result %>.pr.headRefName` when it is available
 - Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
 - Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
 - Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
 - If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -38,6 +38,7 @@ $ARGUMENTS
 - Store the result as `<pr-context>`
 - Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
 - Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
 - Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
 - Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
 - If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
@@ -45,11 +46,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- If `<current-branch>` differs from `<pr-branch>`:
+- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>`
+- Otherwise, if `<current-branch>` is unavailable and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<pr-branch>` as `<active-branch>` because the repository is already aligned to the PR head in detached `HEAD` mode
+- Otherwise:
+  - Run `git fetch origin <pr-branch>` to ensure the branch is available locally before checkout
   - Checkout `<pr-branch>` before analyzing repository files or making code changes for this PR
   - After checkout, store the active branch as `<active-branch>`
   - If checkout fails, STOP and report that the PR branch could not be checked out locally
-- Otherwise, store `<current-branch>` as `<active-branch>`
 - Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`
 
 ### Analyze Feedback

--- a/packages/opencode/.opencode/commands/pr/review.md
+++ b/packages/opencode/.opencode/commands/pr/review.md
@@ -34,6 +34,7 @@ $ARGUMENTS
 - Store the result as `<pr-context>`
 - Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
 - Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
 - Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
 - Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
 - If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
@@ -41,11 +42,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- If `<current-branch>` differs from `<pr-branch>`:
+- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>`
+- Otherwise, if `<current-branch>` is unavailable and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<pr-branch>` as `<active-branch>` because the repository is already aligned to the PR head in detached `HEAD` mode
+- Otherwise:
+  - Run `git fetch origin <pr-branch>` to ensure the branch is available locally before checkout
   - Checkout `<pr-branch>` before inspecting local repository files for this PR review
   - After checkout, store the active branch as `<active-branch>`
   - If checkout fails, STOP and report that the PR branch could not be checked out locally
-- Otherwise, store `<current-branch>` as `<active-branch>`
 - Do not inspect local repository code for this PR until `<active-branch>` equals `<pr-branch>`
 
 ### Load Ticket Context


### PR DESCRIPTION
### Ticket

SKIPPED

## Summary

Fixes a failure in `pr/review` and `pr/fix` commands when run inside GitHub Actions CI/CD pipelines. By default, `actions/checkout@v4` on `pull_request` events checks out the PR merge commit in **detached HEAD** mode — meaning `git branch --show-current` returns empty. The branch alignment logic previously treated any mismatch as a checkout target, but without the branch being fetched locally the checkout would fail and the command would stop.

## Root Cause

GitHub Actions `pull_request` workflows run on a detached HEAD pointing to the synthetic merge commit (`refs/pull/N/merge`), not the PR head branch. The old logic compared `<current-branch>` against `<pr-branch>` and immediately tried `git checkout <pr-branch>` on mismatch — which fails because the branch ref is not available locally in a shallow CI clone.

## Changes

- Added `git rev-parse HEAD` → `<current-head>` to the `load-pr` component to capture the current commit SHA alongside the branch name
- Rewrote branch alignment in `pr/review` and `pr/fix` from a two-way to a three-way check:
  1. `<current-branch>` equals `<pr-branch>` → already on the correct branch, proceed
  2. `<current-branch>` is empty (detached HEAD) and `<current-head>` matches `pr.headRefOid` → already at the correct commit, skip checkout
  3. Otherwise → run `git fetch origin <pr-branch>` first to ensure the branch is available locally, then checkout
- The explicit fetch before checkout makes the commands self-sufficient regardless of how shallow the CI clone is, removing the dependency on `ref: ${{ github.head_ref }}` in the caller's workflow
- Added `ref: ${{ github.head_ref }}` to the checkout step in the Kompass CI workflow so the runner checks out the named branch directly, avoiding detached HEAD entirely and hitting the fast path in the alignment logic