### PR TITLE
fix: load PR change context from the active branch

### DIFF
--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -32,13 +32,18 @@ $ARGUMENTS
 
 <%~ include("@align-pr-branch", { action: "analyzing repository files or making code changes for this PR", scope: "inspect or modify local code for this PR" }) %>
 
+### Load Changes
+
+Call `changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <active-branch>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
+
 ### Analyze Feedback
 
 Separate true course corrections from noise or already-resolved feedback:
 1. Review `<pr-context.threads>` for open, unresolved conversations
 2. Check `<pr-context.reviews>` for state changes (CHANGES_REQUESTED, etc.)
-3. Prioritize critical issues (bugs, security, broken contracts)
-4. Identify which files need changes
+3. Use `<changes>` to understand the current PR diff before deciding what to adjust
+4. Prioritize critical issues (bugs, security, broken contracts)
+5. Identify which files need changes
 
 Do not blindly follow every suggestion—some may lead you off course.
 

--- a/packages/core/commands/pr/review.md
+++ b/packages/core/commands/pr/review.md
@@ -37,7 +37,7 @@ If `<pr-context.pr.body>` links to exactly one clear ticket:
 
 ### Load Changes
 
-Call `changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <pr-context.pr.headRefName>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
+Call `changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <active-branch>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
 
 ### Review Changes
 

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -50,13 +50,18 @@ $ARGUMENTS
 - If checkout fails, STOP and report that the PR branch could not be checked out locally
 - Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`
 
+### Load Changes
+
+Call `kompass_changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <active-branch>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
+
 ### Analyze Feedback
 
 Separate true course corrections from noise or already-resolved feedback:
 1. Review `<pr-context.threads>` for open, unresolved conversations
 2. Check `<pr-context.reviews>` for state changes (CHANGES_REQUESTED, etc.)
-3. Prioritize critical issues (bugs, security, broken contracts)
-4. Identify which files need changes
+3. Use `<changes>` to understand the current PR diff before deciding what to adjust
+4. Prioritize critical issues (bugs, security, broken contracts)
+5. Identify which files need changes
 
 Do not blindly follow every suggestion—some may lead you off course.
 

--- a/packages/opencode/.opencode/commands/pr/review.md
+++ b/packages/opencode/.opencode/commands/pr/review.md
@@ -59,7 +59,7 @@ If `<pr-context.pr.body>` links to exactly one clear ticket:
 
 ### Load Changes
 
-Call `kompass_changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <pr-context.pr.headRefName>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
+Call `kompass_changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <active-branch>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
 
 ### Review Changes
 


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Use the active local branch when loading PR change context so follow-up review and fix flows analyze the branch being worked on instead of relying on the PR head ref.

## Checklist
### PR fix workflow
- [x] Confirm PR fix analysis loads changes from the active local branch
- [x] Confirm feedback triage uses the current branch diff before selecting edits

### PR review workflow
- [x] Confirm PR review analysis loads changes from the active local branch
- [x] Confirm review comments are based on the checked-out branch diff

### Generated OpenCode output
- [x] Confirm generated OpenCode PR command docs stay aligned with the source command docs

### Validation
- [x] Verify that the updated command docs accurately describe the intended branch context
- [x] Check that source and generated command definitions stay in sync