### PR TITLE
docs: clarify ticket/ask command is read-only

### DIFF
--- a/packages/core/commands/ticket/ask.md
+++ b/packages/core/commands/ticket/ask.md
@@ -7,6 +7,7 @@ Load a ticket and its discussion, answer the user's question, and post that answ
 - Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
 - Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
 - Ask only when the ticket source or question cannot be determined reliably
+- This command is strictly for understanding and replying; do NOT write, edit, or commit any code
 
 ## Workflow
 
@@ -33,6 +34,7 @@ $ARGUMENTS
 - Use `<ticket-context>` to understand the request, history, and open questions
 - Answer `<question>` using the ticket discussion plus any necessary repository context
 - Store the response to post as `<ticket-answer>`
+- Do NOT modify, create, or delete any files; do NOT run git commit or push
 
 ### Sync Ticket
 

--- a/packages/opencode/.opencode/commands/ticket/ask.md
+++ b/packages/opencode/.opencode/commands/ticket/ask.md
@@ -12,6 +12,7 @@ Load a ticket and its discussion, answer the user's question, and post that answ
 - Use `<additional-context>` to shape tone, depth, and focus for `<ticket-answer>`
 - Keep the posted answer grounded in the actual ticket discussion; do not invent missing facts
 - Ask only when the ticket source or question cannot be determined reliably
+- This command is strictly for understanding and replying; do NOT write, edit, or commit any code
 
 ## Workflow
 
@@ -42,6 +43,7 @@ $ARGUMENTS
 - Use `<ticket-context>` to understand the request, history, and open questions
 - Answer `<question>` using the ticket discussion plus any necessary repository context
 - Store the response to post as `<ticket-answer>`
+- Do NOT modify, create, or delete any files; do NOT run git commit or push
 
 ### Sync Ticket
 


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Clarifies that the `ticket/ask` command is strictly for understanding and replying to tickets. It does not write, edit, or commit any code.

## Checklist

### Documentation
- [x] Clarify ticket/ask command intent in core command definition
- [x] Regenerate OpenCode command output with matching clarification

### Validation
- [ ] Verify that both command files include the read-only note
- [ ] Confirm that wording matches between source and generated output