### PR TITLE
Skip redundant PR checkout at head commit

### DIFF
--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -30,7 +30,7 @@ $ARGUMENTS
 
 ### Align Local Branch
 
-<%~ include("@align-pr-branch", { action: "analyzing repository files or making code changes for this PR", scope: "inspect or modify local code for this PR" }) %>
+<%~ include("@align-pr-branch", { action: "analyzing repository files or making code changes for this PR", scope: "inspect or modify local code for this PR", requiresBranch: true }) -%>
 
 ### Load Changes
 

--- a/packages/core/commands/pr/review.md
+++ b/packages/core/commands/pr/review.md
@@ -26,7 +26,7 @@ $ARGUMENTS
 
 ### Align Local Branch
 
-<%~ include("@align-pr-branch", { action: "inspecting local repository files for this PR review", scope: "inspect local repository code for this PR" }) %>
+<%~ include("@align-pr-branch", { action: "inspecting local repository files for this PR review", scope: "inspect local repository code for this PR", requiresBranch: false }) -%>
 
 ### Load Ticket Context
 

--- a/packages/core/components/align-pr-branch.md
+++ b/packages/core/components/align-pr-branch.md
@@ -1,8 +1,18 @@
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>` and do not checkout again
-- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-head>` as `<active-branch>` and do not checkout because the worktree is already at the PR head commit
-- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` differs from `<pr-context.pr.headRefOid>`:
+<% if (it.requiresBranch) { -%>
+- If `<current-branch>` equals `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-branch>` as `<active-branch>` and do not checkout again
+- If `<current-branch>` differs from `<pr-branch>` or `<current-head>` differs from `<pr-context.pr.headRefOid>`:
   - Run `gh pr checkout <pr-context.pr.number>` before <%= it.action %>
   - After checkout, store the active branch as `<active-branch>`
+  - Run `git rev-parse HEAD` again and store the trimmed result as `<current-head>`
   - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
-- Do not <%= it.scope %> until `<active-branch>` equals `<pr-branch>` or `<active-branch>` equals `<pr-context.pr.headRefOid>`
+- Do not <%= it.scope %> until `<active-branch>` equals `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`
+<% } else { -%>
+- If `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-branch>` as `<active-branch>` when `<current-branch>` is available; otherwise store `<current-head>` as `<active-branch>`. Do not checkout because the worktree is already at the PR head commit.
+- If `<current-head>` differs from `<pr-context.pr.headRefOid>`:
+  - Run `gh pr checkout <pr-context.pr.number>` before <%= it.action %>
+  - After checkout, store the active branch as `<active-branch>`
+  - Run `git rev-parse HEAD` again and store the trimmed result as `<current-head>`
+  - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
+- Do not <%= it.scope %> until `<current-head>` equals `<pr-context.pr.headRefOid>`
+<% } -%>

--- a/packages/core/components/align-pr-branch.md
+++ b/packages/core/components/align-pr-branch.md
@@ -1,5 +1,8 @@
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- Run `gh pr checkout <pr-context.pr.number>` before <%= it.action %>
-- After checkout, store the active branch as `<active-branch>`
-- If checkout fails, STOP and report that the PR branch could not be checked out locally
-- Do not <%= it.scope %> until `<active-branch>` equals `<pr-branch>`
+- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>` and do not checkout again
+- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-head>` as `<active-branch>` and do not checkout because the worktree is already at the PR head commit
+- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` differs from `<pr-context.pr.headRefOid>`:
+  - Run `gh pr checkout <pr-context.pr.number>` before <%= it.action %>
+  - After checkout, store the active branch as `<active-branch>`
+  - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
+- Do not <%= it.scope %> until `<active-branch>` equals `<pr-branch>` or `<active-branch>` equals `<pr-context.pr.headRefOid>`

--- a/packages/core/components/load-pr.md
+++ b/packages/core/components/load-pr.md
@@ -5,6 +5,7 @@
 - Store the result as `<%= it.result %>`
 - Store the PR head branch as `<pr-branch>` from `<%= it.result %>.pr.headRefName` when it is available
 - Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
 - Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
 - Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
 - If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably

--- a/packages/core/test/commands.test.ts
+++ b/packages/core/test/commands.test.ts
@@ -14,14 +14,22 @@ describe("resolveCommands", () => {
     assert.deepEqual(commands["pr/review"]?.config, { enabled: true });
   });
 
-  test("skips PR checkout when pr/review is already on PR branch or commit", async () => {
+  test("skips PR checkout when pr/review is already at PR head", async () => {
     const commands = await resolveCommands(process.cwd());
     const template = commands["pr/review"]?.template ?? "";
 
     assert.match(template, /git rev-parse HEAD/);
-    assert.match(template, /If `<current-branch>` equals `<pr-branch>`/);
     assert.match(template, /`<current-head>` equals `<pr-context\.pr\.headRefOid>`/);
     assert.match(template, /Run `gh pr checkout <pr-context\.pr\.number>`/);
     assert.match(template, /do not retry checkout unless the user explicitly asks/);
+  });
+
+  test("requires PR branch for pr/fix checkout alignment", async () => {
+    const commands = await resolveCommands(process.cwd());
+    const template = commands["pr/fix"]?.template ?? "";
+
+    assert.match(template, /`<current-branch>` equals `<pr-branch>` and `<current-head>` equals `<pr-context\.pr\.headRefOid>`/);
+    assert.match(template, /`<current-branch>` differs from `<pr-branch>` or `<current-head>` differs from `<pr-context\.pr\.headRefOid>`/);
+    assert.match(template, /Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>` and `<current-head>` equals `<pr-context\.pr\.headRefOid>`/);
   });
 });

--- a/packages/core/test/commands.test.ts
+++ b/packages/core/test/commands.test.ts
@@ -13,4 +13,15 @@ describe("resolveCommands", () => {
 
     assert.deepEqual(commands["pr/review"]?.config, { enabled: true });
   });
+
+  test("skips PR checkout when pr/review is already on PR branch or commit", async () => {
+    const commands = await resolveCommands(process.cwd());
+    const template = commands["pr/review"]?.template ?? "";
+
+    assert.match(template, /git rev-parse HEAD/);
+    assert.match(template, /If `<current-branch>` equals `<pr-branch>`/);
+    assert.match(template, /`<current-head>` equals `<pr-context\.pr\.headRefOid>`/);
+    assert.match(template, /Run `gh pr checkout <pr-context\.pr\.number>`/);
+    assert.match(template, /do not retry checkout unless the user explicitly asks/);
+  });
 });

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -38,6 +38,7 @@ $ARGUMENTS
 - Store the result as `<pr-context>`
 - Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
 - Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
 - Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
 - Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
 - If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
@@ -45,10 +46,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- Run `gh pr checkout <pr-context.pr.number>` before analyzing repository files or making code changes for this PR
-- After checkout, store the active branch as `<active-branch>`
-- If checkout fails, STOP and report that the PR branch could not be checked out locally
-- Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`
+- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>` and do not checkout again
+- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-head>` as `<active-branch>` and do not checkout because the worktree is already at the PR head commit
+- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` differs from `<pr-context.pr.headRefOid>`:
+  - Run `gh pr checkout <pr-context.pr.number>` before analyzing repository files or making code changes for this PR
+  - After checkout, store the active branch as `<active-branch>`
+  - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
+- Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>` or `<active-branch>` equals `<pr-context.pr.headRefOid>`
 
 ### Load Changes
 

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -46,13 +46,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>` and do not checkout again
-- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-head>` as `<active-branch>` and do not checkout because the worktree is already at the PR head commit
-- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` differs from `<pr-context.pr.headRefOid>`:
+- If `<current-branch>` equals `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-branch>` as `<active-branch>` and do not checkout again
+- If `<current-branch>` differs from `<pr-branch>` or `<current-head>` differs from `<pr-context.pr.headRefOid>`:
   - Run `gh pr checkout <pr-context.pr.number>` before analyzing repository files or making code changes for this PR
   - After checkout, store the active branch as `<active-branch>`
+  - Run `git rev-parse HEAD` again and store the trimmed result as `<current-head>`
   - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
-- Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>` or `<active-branch>` equals `<pr-context.pr.headRefOid>`
+- Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`
 
 ### Load Changes
 

--- a/packages/opencode/.opencode/commands/pr/review.md
+++ b/packages/opencode/.opencode/commands/pr/review.md
@@ -34,6 +34,7 @@ $ARGUMENTS
 - Store the result as `<pr-context>`
 - Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
 - Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
 - Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
 - Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
 - If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
@@ -41,10 +42,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- Run `gh pr checkout <pr-context.pr.number>` before inspecting local repository files for this PR review
-- After checkout, store the active branch as `<active-branch>`
-- If checkout fails, STOP and report that the PR branch could not be checked out locally
-- Do not inspect local repository code for this PR until `<active-branch>` equals `<pr-branch>`
+- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>` and do not checkout again
+- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-head>` as `<active-branch>` and do not checkout because the worktree is already at the PR head commit
+- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` differs from `<pr-context.pr.headRefOid>`:
+  - Run `gh pr checkout <pr-context.pr.number>` before inspecting local repository files for this PR review
+  - After checkout, store the active branch as `<active-branch>`
+  - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
+- Do not inspect local repository code for this PR until `<active-branch>` equals `<pr-branch>` or `<active-branch>` equals `<pr-context.pr.headRefOid>`
 
 ### Load Ticket Context
 

--- a/packages/opencode/.opencode/commands/pr/review.md
+++ b/packages/opencode/.opencode/commands/pr/review.md
@@ -42,13 +42,13 @@ $ARGUMENTS
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- If `<current-branch>` equals `<pr-branch>`, store `<current-branch>` as `<active-branch>` and do not checkout again
-- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-head>` as `<active-branch>` and do not checkout because the worktree is already at the PR head commit
-- If `<current-branch>` differs from `<pr-branch>` and `<current-head>` differs from `<pr-context.pr.headRefOid>`:
+- If `<current-head>` equals `<pr-context.pr.headRefOid>`, store `<current-branch>` as `<active-branch>` when `<current-branch>` is available; otherwise store `<current-head>` as `<active-branch>`. Do not checkout because the worktree is already at the PR head commit.
+- If `<current-head>` differs from `<pr-context.pr.headRefOid>`:
   - Run `gh pr checkout <pr-context.pr.number>` before inspecting local repository files for this PR review
   - After checkout, store the active branch as `<active-branch>`
+  - Run `git rev-parse HEAD` again and store the trimmed result as `<current-head>`
   - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
-- Do not inspect local repository code for this PR until `<active-branch>` equals `<pr-branch>` or `<active-branch>` equals `<pr-context.pr.headRefOid>`
+- Do not inspect local repository code for this PR until `<current-head>` equals `<pr-context.pr.headRefOid>`
 
 ### Load Ticket Context
 


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Avoid unnecessary PR checkout attempts when review or fix commands are already on the PR branch or exact head commit, reducing avoidable failures while preserving branch safety checks.

## Checklist
### PR Branch Alignment
- [x] Skip checkout when already on the PR branch
- [x] Skip checkout when the current HEAD matches the PR head commit
- [x] Keep checkout required when neither the branch nor commit matches

### Command Coverage
- [x] Apply the alignment behavior to PR review and fix command output
- [x] Cover the rendered PR review template expectations

### Validation
- [x] Verify that PR review does not retry checkout when already at the PR head commit
- [x] Confirm that PR fix still checks out the branch when local state differs from the PR head