### PR TITLE
Add loop PR fix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Kompass keeps AI coding agents on course with token-efficient, composable workfl
 
 ## Bundled Surface
 
-- Commands cover direct work (`/ask`, `/commit`, `/merge`, `/skill/create`, `/skill/optimize`), orchestration (`/dev`, `/ship`, `/todo`), ticket planning/sync, and PR review/shipping flows.
+- Commands cover direct work (`/ask`, `/commit`, `/merge`, `/skill/create`, `/skill/optimize`), orchestration (`/dev`, `/ship`, `/todo`, `/loop/pr/fix`), ticket planning/sync, and PR review/shipping flows.
 - Agents are intentionally narrow: `worker` is generic, `planner` is no-edit planning, `navigator` owns multi-step orchestration, and `reviewer` is a no-edit review specialist.
 - Structured tools keep workflows grounded in repo and GitHub state: `changes_load`, `command_expansion` (resolve a slash command and return the expanded prompt for immediate delegation), `pr_load`, `pr_sync`, `ticket_load`, `ticket_sync`.
 - Reusable command-template components live in `packages/core/components/` and are documented in the components reference.

--- a/kompass.jsonc
+++ b/kompass.jsonc
@@ -17,6 +17,7 @@
     "commit-and-push": { "enabled": true },
     "dev": { "enabled": true },
     "learn": { "enabled": true },
+    "loop/pr/fix": { "enabled": true },
     "merge": { "enabled": true },
     "pr/create": { "enabled": true },
     "pr/fix": { "enabled": true },

--- a/kompass.schema.json
+++ b/kompass.schema.json
@@ -50,6 +50,9 @@
         "learn": {
           "$ref": "#/$defs/commandConfig"
         },
+        "loop/pr/fix": {
+          "$ref": "#/$defs/commandConfig"
+        },
         "merge": {
           "$ref": "#/$defs/commandConfig"
         },
@@ -106,6 +109,7 @@
               "commit-and-push",
               "dev",
               "learn",
+              "loop/pr/fix",
               "merge",
               "pr/create",
               "pr/fix",
@@ -136,6 +140,7 @@
               "commit-and-push",
               "dev",
               "learn",
+              "loop/pr/fix",
               "merge",
               "pr/create",
               "pr/fix",

--- a/packages/core/commands/index.ts
+++ b/packages/core/commands/index.ts
@@ -51,6 +51,11 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
     templatePath: "commands/learn.md",
     subtask: false,
   },
+  "loop/pr/fix": {
+    description: "Watch PR CI and comments, repeatedly fixing both without approval prompts",
+    agent: "navigator",
+    templatePath: "commands/loop/pr/fix.md",
+  },
   merge: {
     description: "Merge a branch and auto-resolve conflicts best-effort",
     agent: "worker",
@@ -62,7 +67,7 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
     templatePath: "commands/pr/create.md",
   },
   "pr/fix": {
-    description: "Fix PR feedback, push updates, and reply",
+    description: "Fix PR feedback or CI failures, push updates, and reply",
     agent: "worker",
     templatePath: "commands/pr/fix.md",
     subtask: false,

--- a/packages/core/commands/loop/pr/fix.md
+++ b/packages/core/commands/loop/pr/fix.md
@@ -1,0 +1,93 @@
+## Goal
+
+Continuously watch a pull request, fix CI failures and PR feedback, commit, push, reply, and repeat until the PR is clean.
+
+## Additional Context
+
+Use `<additional-context>` to constrain which feedback should be handled, how aggressive the fix pass should be, or which CI checks matter when the PR has optional checks.
+- This command is intentionally non-interactive: do not ask for approval before delegated fix work, commits, pushes, or PR replies.
+- CI failures are part of the loop: capture them as actionable work, fix them, push, then watch CI again.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` looks like a PR number or URL, store it as `<pr-ref>`
+- If `<arguments>` includes extra fix guidance, CI guidance, or scope constraints, store it as `<additional-context>`
+- If empty, leave `<pr-ref>` undefined and let `<%= it.config.tools.pr_load.name %>` resolve the default PR context
+- Initialize `<completed-fix-passes>` as `0`
+
+### Load PR Context
+
+<%~ include("@load-pr", { config: it.config, ref: "<pr-ref>", result: "<pr-context>" }) %>
+
+- Store `<pr-url>` as `<pr-context.pr.url>`
+- Store `<pr-number>` as `<pr-context.pr.number>`
+- STOP if `<pr-url>` or `<pr-number>` is unavailable
+
+### Watch CI And Comments
+
+- Run `gh pr checks <pr-number> --watch` to wait for the latest PR checks to finish
+- If the command exits successfully, store `<ci-status>` as `green`
+- If there are no checks configured for the PR, store `<ci-status>` as `no checks`
+- If the command reports failing, cancelled, timed out, missing, or inconclusive checks, store `<ci-status>` with that state and capture the failing check names, URLs, and failure output as `<ci-failures>`
+- Do not STOP only because CI failed; failed checks are actionable feedback for this loop
+
+### Reload PR Feedback
+
+Call `<%= it.config.tools.pr_load.name %>` with `<pr-url>` and store the refreshed result as `<fresh-pr-context>`.
+
+- Review `<fresh-pr-context.threads>`, `<fresh-pr-context.reviews>`, and `<fresh-pr-context.issueComments>`
+- Identify open, unresolved, actionable reviewer feedback that has not already been answered by the author or superseded by later commits
+- Combine actionable reviewer feedback and `<ci-failures>` into `<actionable-work>`
+- Store the number of actionable reviewer items as `<actionable-feedback-count>`
+- Store the number of actionable CI failures as `<actionable-ci-count>`
+- If `<actionable-feedback-count>` and `<actionable-ci-count>` are both `0`, continue to `### Output`
+
+### Delegate Fix Pass
+
+<delegate agent="<%= it.config.agents.worker.name %>" command="<%= it.config.commands["pr/fix"].name %>">
+auto <pr-url>
+
+Fix all actionable PR review feedback and CI failures from the latest loop pass.
+CI status: <ci-status>
+CI failures: <ci-failures>
+Actionable work: <actionable-work>
+Additional context: <additional-context>
+</delegate>
+
+- Store the delegated result as `<fix-result>`
+- If `<fix-result>` is blocked, incomplete, reports failing validation, or reports that push or PR replies failed, STOP and report the fix blocker
+- If `<fix-result>` reports that no changes were made for actionable work, STOP and report that manual follow-up is needed to avoid looping on unchanged CI or feedback
+- Otherwise, increment `<completed-fix-passes>` by `1` and return to `### Load PR Context`
+
+### Output
+
+If stopped by a delegated fix blocker, display:
+```
+PR loop blocked for #<pr-number>
+
+- CI status: <ci-status>
+- Fix passes completed: <completed-fix-passes>
+- Blocker: <fix-result>
+
+No additional steps are required.
+```
+
+When complete, display:
+```
+PR loop complete for #<pr-number>
+
+- CI status: <ci-status>
+- CI failures remaining: 0
+- Actionable feedback remaining: 0
+- Fix passes completed: <completed-fix-passes>
+
+No additional steps are required.
+```

--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -1,10 +1,10 @@
 ## Goal
 
-Address feedback on a pull request by making fixes and responding to review threads.
+Address feedback or CI failures on a pull request by making fixes and responding to review threads.
 
 ## Additional Context
 
-Use `<additional-context>` when prioritizing which review feedback to address first and when deciding how much scope to take on in this pass.
+Use `<additional-context>` when prioritizing which review feedback or CI failure to address first and when deciding how much scope to take on in this pass.
 - Default `/pr/fix` behavior is review-first: show the proposed fix, gather feedback, and loop until the user approves before committing, pushing, or replying on the PR.
 - Treat `/pr/fix auto` as the explicit opt-in to skip the approval loop and proceed directly from passing validation to commit, push, and PR replies.
 
@@ -45,9 +45,10 @@ Call `<%= it.config.tools.changes_load.name %>` with `base: <pr-context.pr.baseR
 Separate true course corrections from noise or already-resolved feedback:
 1. Review `<pr-context.threads>` for open, unresolved conversations
 2. Check `<pr-context.reviews>` for state changes (CHANGES_REQUESTED, etc.)
-3. Use `<changes>` to understand the current PR diff before deciding what to adjust
-4. Prioritize critical issues (bugs, security, broken contracts)
-5. Identify which files need changes
+3. Include any CI failures, logs, failing check names, or reproduction details provided in `<additional-context>` as actionable feedback
+4. Use `<changes>` to understand the current PR diff before deciding what to adjust
+5. Prioritize critical issues (bugs, security, broken contracts, failing required checks)
+6. Identify which files need changes
 
 Do not blindly follow every suggestion—some may lead you off course.
 
@@ -85,7 +86,7 @@ Run the most relevant available validation for the fixes:
     - Keep custom answers enabled so the user can provide concrete feedback
   - If `<changes-count>` is `0`, ask exactly one `question` with:
     - header `Need Feedback`
-    - question `I did not make any changes for this PR feedback. What should I revise or investigate next?`
+    - question `I did not make any changes for this PR feedback or CI failure. What should I revise or investigate next?`
     - options:
       - `Revise` - provide feedback for another pass
       - `Stop Here` - stop without committing, pushing, or replying on the PR

--- a/packages/core/kompass.jsonc
+++ b/packages/core/kompass.jsonc
@@ -17,6 +17,7 @@
     "commit-and-push": { "enabled": true },
     "dev": { "enabled": true },
     "learn": { "enabled": true },
+    "loop/pr/fix": { "enabled": true },
     "merge": { "enabled": true },
     "pr/create": { "enabled": true },
     "pr/fix": { "enabled": true },

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -29,6 +29,7 @@ export const DEFAULT_COMMAND_NAMES = [
   "commit-and-push",
   "dev",
   "learn",
+  "loop/pr/fix",
   "merge",
   "pr/create",
   "pr/fix",
@@ -97,6 +98,7 @@ export interface KompassConfig {
     "commit-and-push"?: CommandConfig;
     dev?: CommandConfig;
     learn?: CommandConfig;
+    "loop/pr/fix"?: CommandConfig;
     merge?: CommandConfig;
     "pr/create"?: CommandConfig;
     "pr/fix"?: CommandConfig;

--- a/packages/core/test/commands.test.ts
+++ b/packages/core/test/commands.test.ts
@@ -32,4 +32,14 @@ describe("resolveCommands", () => {
     assert.match(template, /Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`/);
     assert.doesNotMatch(template, /`<current-branch>` differs from `<pr-branch>` or `<current-head>` differs from `<pr-context\.pr\.headRefOid>`/);
   });
+
+  test("orchestrates loop pr fix through ci and delegated auto fixes", async () => {
+    const commands = await resolveCommands(process.cwd());
+    const template = commands["loop/pr/fix"]?.template ?? "";
+
+    assert.match(template, /gh pr checks <pr-number> --watch/);
+    assert.match(template, /command="pr\/fix"/);
+    assert.match(template, /auto <pr-url>/);
+    assert.doesNotMatch(template, /question/);
+  });
 });

--- a/packages/opencode/.opencode/commands/loop/pr/fix.md
+++ b/packages/opencode/.opencode/commands/loop/pr/fix.md
@@ -1,0 +1,108 @@
+---
+description: Watch PR CI and comments, repeatedly fixing both without approval prompts
+agent: navigator
+---
+
+## Goal
+
+Continuously watch a pull request, fix CI failures and PR feedback, commit, push, reply, and repeat until the PR is clean.
+
+## Additional Context
+
+Use `<additional-context>` to constrain which feedback should be handled, how aggressive the fix pass should be, or which CI checks matter when the PR has optional checks.
+- This command is intentionally non-interactive: do not ask for approval before delegated fix work, commits, pushes, or PR replies.
+- CI failures are part of the loop: capture them as actionable work, fix them, push, then watch CI again.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` looks like a PR number or URL, store it as `<pr-ref>`
+- If `<arguments>` includes extra fix guidance, CI guidance, or scope constraints, store it as `<additional-context>`
+- If empty, leave `<pr-ref>` undefined and let `kompass_pr_load` resolve the default PR context
+- Initialize `<completed-fix-passes>` as `0`
+
+### Load PR Context
+
+- Use `kompass_pr_load` as the source of truth for PR selection
+- If `<pr-ref>` is defined, call `kompass_pr_load` with `pr: <pr-ref>`
+- Otherwise, call `kompass_pr_load` with no arguments
+- Do not run separate git or GitHub commands just to discover the PR before calling `kompass_pr_load`
+- Store the result as `<pr-context>`
+- Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
+- Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
+- Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
+- Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
+- If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
+
+- Store `<pr-url>` as `<pr-context.pr.url>`
+- Store `<pr-number>` as `<pr-context.pr.number>`
+- STOP if `<pr-url>` or `<pr-number>` is unavailable
+
+### Watch CI And Comments
+
+- Run `gh pr checks <pr-number> --watch` to wait for the latest PR checks to finish
+- If the command exits successfully, store `<ci-status>` as `green`
+- If there are no checks configured for the PR, store `<ci-status>` as `no checks`
+- If the command reports failing, cancelled, timed out, missing, or inconclusive checks, store `<ci-status>` with that state and capture the failing check names, URLs, and failure output as `<ci-failures>`
+- Do not STOP only because CI failed; failed checks are actionable feedback for this loop
+
+### Reload PR Feedback
+
+Call `kompass_pr_load` with `<pr-url>` and store the refreshed result as `<fresh-pr-context>`.
+
+- Review `<fresh-pr-context.threads>`, `<fresh-pr-context.reviews>`, and `<fresh-pr-context.issueComments>`
+- Identify open, unresolved, actionable reviewer feedback that has not already been answered by the author or superseded by later commits
+- Combine actionable reviewer feedback and `<ci-failures>` into `<actionable-work>`
+- Store the number of actionable reviewer items as `<actionable-feedback-count>`
+- Store the number of actionable CI failures as `<actionable-ci-count>`
+- If `<actionable-feedback-count>` and `<actionable-ci-count>` are both `0`, continue to `### Output`
+
+### Delegate Fix Pass
+
+<delegate agent="worker" command="pr/fix">
+auto <pr-url>
+
+Fix all actionable PR review feedback and CI failures from the latest loop pass.
+CI status: <ci-status>
+CI failures: <ci-failures>
+Actionable work: <actionable-work>
+Additional context: <additional-context>
+</delegate>
+
+- Store the delegated result as `<fix-result>`
+- If `<fix-result>` is blocked, incomplete, reports failing validation, or reports that push or PR replies failed, STOP and report the fix blocker
+- If `<fix-result>` reports that no changes were made for actionable work, STOP and report that manual follow-up is needed to avoid looping on unchanged CI or feedback
+- Otherwise, increment `<completed-fix-passes>` by `1` and return to `### Load PR Context`
+
+### Output
+
+If stopped by a delegated fix blocker, display:
+```
+PR loop blocked for #<pr-number>
+
+- CI status: <ci-status>
+- Fix passes completed: <completed-fix-passes>
+- Blocker: <fix-result>
+
+No additional steps are required.
+```
+
+When complete, display:
+```
+PR loop complete for #<pr-number>
+
+- CI status: <ci-status>
+- CI failures remaining: 0
+- Actionable feedback remaining: 0
+- Fix passes completed: <completed-fix-passes>
+
+No additional steps are required.
+```

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -1,15 +1,15 @@
 ---
-description: Fix PR feedback, push updates, and reply
+description: Fix PR feedback or CI failures, push updates, and reply
 agent: worker
 ---
 
 ## Goal
 
-Address feedback on a pull request by making fixes and responding to review threads.
+Address feedback or CI failures on a pull request by making fixes and responding to review threads.
 
 ## Additional Context
 
-Use `<additional-context>` when prioritizing which review feedback to address first and when deciding how much scope to take on in this pass.
+Use `<additional-context>` when prioritizing which review feedback or CI failure to address first and when deciding how much scope to take on in this pass.
 - Default `/pr/fix` behavior is review-first: show the proposed fix, gather feedback, and loop until the user approves before committing, pushing, or replying on the PR.
 - Treat `/pr/fix auto` as the explicit opt-in to skip the approval loop and proceed directly from passing validation to commit, push, and PR replies.
 
@@ -60,9 +60,10 @@ Call `kompass_changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <ac
 Separate true course corrections from noise or already-resolved feedback:
 1. Review `<pr-context.threads>` for open, unresolved conversations
 2. Check `<pr-context.reviews>` for state changes (CHANGES_REQUESTED, etc.)
-3. Use `<changes>` to understand the current PR diff before deciding what to adjust
-4. Prioritize critical issues (bugs, security, broken contracts)
-5. Identify which files need changes
+3. Include any CI failures, logs, failing check names, or reproduction details provided in `<additional-context>` as actionable feedback
+4. Use `<changes>` to understand the current PR diff before deciding what to adjust
+5. Prioritize critical issues (bugs, security, broken contracts, failing required checks)
+6. Identify which files need changes
 
 Do not blindly follow every suggestion—some may lead you off course.
 
@@ -99,7 +100,7 @@ Run the most relevant available validation for the fixes:
     - Keep custom answers enabled so the user can provide concrete feedback
   - If `<changes-count>` is `0`, ask exactly one `question` with:
     - header `Need Feedback`
-    - question `I did not make any changes for this PR feedback. What should I revise or investigate next?`
+    - question `I did not make any changes for this PR feedback or CI failure. What should I revise or investigate next?`
     - options:
       - `Revise` - provide feedback for another pass
       - `Stop Here` - stop without committing, pushing, or replying on the PR

--- a/packages/opencode/.opencode/kompass.jsonc
+++ b/packages/opencode/.opencode/kompass.jsonc
@@ -25,6 +25,9 @@
     "learn": {
       "enabled": true
     },
+    "loop/pr/fix": {
+      "enabled": true
+    },
     "merge": {
       "enabled": true
     },

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -18,7 +18,7 @@ Kompass keeps AI coding agents on course with token-efficient, composable workfl
 
 ## Bundled Surface
 
-- Commands cover direct work (`/ask`, `/commit`, `/merge`, `/skill/create`, `/skill/optimize`), orchestration (`/dev`, `/ship`, `/todo`), ticket planning/sync, and PR review/shipping flows.
+- Commands cover direct work (`/ask`, `/commit`, `/merge`, `/skill/create`, `/skill/optimize`), orchestration (`/dev`, `/ship`, `/todo`, `/loop/pr/fix`), ticket planning/sync, and PR review/shipping flows.
 - Agents are intentionally narrow: `worker` is generic, `planner` is no-edit planning, `navigator` owns multi-step orchestration, and `reviewer` is a no-edit review specialist.
 - Structured tools keep workflows grounded in repo and GitHub state: `changes_load`, `command_expansion` (resolve a slash command and return the expanded prompt for immediate delegation), `pr_load`, `pr_sync`, `ticket_load`, `ticket_sync`.
 - Reusable command-template components live in `packages/core/components/` and are documented in the components reference.

--- a/packages/opencode/kompass.jsonc
+++ b/packages/opencode/kompass.jsonc
@@ -17,6 +17,7 @@
     "commit-and-push": { "enabled": true },
     "dev": { "enabled": true },
     "learn": { "enabled": true },
+    "loop/pr/fix": { "enabled": true },
     "merge": { "enabled": true },
     "pr/create": { "enabled": true },
     "pr/fix": { "enabled": true },

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -34,6 +34,7 @@ describe("applyCommandsConfig", () => {
       const expectedCommands = [
         "ask",
         "branch",
+        "loop/pr/fix",
         "merge",
         "pr/create",
         "pr/review",
@@ -73,11 +74,13 @@ describe("applyCommandsConfig", () => {
       assert.equal(cfg.command!["ask"]?.agent, "worker");
       assert.equal(cfg.command!["ticket/ask"]?.agent, "worker");
       assert.equal(cfg.command!["dev"]?.agent, "navigator");
+      assert.equal(cfg.command!["loop/pr/fix"]?.agent, "navigator");
       assert.equal(cfg.command!["ship"]?.agent, "navigator");
       assert.equal(cfg.command!["todo"]?.agent, "navigator");
       assert.equal(cfg.command!["ticket/dev"]?.agent, "navigator");
       assert.ok(cfg.command!["pr/review"]?.description);
       assert.ok(cfg.command!["dev"]?.template);
+      assert.ok(cfg.command!["loop/pr/fix"]?.template);
       assert.ok(cfg.command!["branch"]?.template);
     });
   });
@@ -377,6 +380,7 @@ describe("applyCommandsConfig", () => {
       assert.equal(cfg.command!["pr/fix"]?.subtask, false);
       assert.equal(cfg.command!["pr/review"]?.subtask, true);
       assert.equal(cfg.command!["dev"]?.subtask, true);
+      assert.equal(cfg.command!["loop/pr/fix"]?.subtask, true);
       assert.equal(cfg.command!["ship"]?.subtask, true);
       assert.equal(cfg.command!["todo"]?.subtask, true);
     });
@@ -391,6 +395,7 @@ describe("applyCommandsConfig", () => {
       assert.equal(cfg.command!["pr/fix"]?.subtask, false);
       assert.equal(cfg.command!["pr/review"]?.subtask, false);
       assert.equal(cfg.command!["dev"]?.subtask, false);
+      assert.equal(cfg.command!["loop/pr/fix"]?.subtask, false);
       assert.equal(cfg.command!["ship"]?.subtask, false);
       assert.equal(cfg.command!["todo"]?.subtask, false);
     });
@@ -456,6 +461,7 @@ describe("applyCommandsConfig", () => {
       assert.ok(cfg.command!["pr/fix"]?.template);
       assert.ok(cfg.command!["skill/create"]?.template);
       assert.ok(cfg.command!["skill/optimize"]?.template);
+      assert.ok(cfg.command!["loop/pr/fix"]?.template);
       assert.ok(cfg.command!["ship"]?.template);
       assert.ok(cfg.command!["ticket/dev"]?.template);
       assert.ok(cfg.command!["review"]?.template);

--- a/packages/web/src/components/CommandShowcase.astro
+++ b/packages/web/src/components/CommandShowcase.astro
@@ -437,6 +437,29 @@ const scenarios: CommandScenario[] = [
     ]
   },
   {
+    id: 'loop-pr-fix',
+    label: '/loop/pr/fix',
+    command: '/loop/pr/fix 51',
+    agentName: 'Navigator',
+    task: 'Watch PR CI and comments, then fix both hands-off',
+    group: 'orchestration',
+    steps: [
+      { id: 'thinking', phase: 'thinking', content: 'Load the PR, wait for checks to finish, reload comments, delegate a non-interactive fix pass for CI and feedback, then repeat until clean.' },
+      { id: 'tools', phase: 'tool_calls', toolCalls: [
+        { tool: 'pr_load', args: 'PR #51', status: 'complete' },
+        { tool: 'bash', args: 'gh pr checks 51 --watch', status: 'complete' },
+        { tool: 'pr_load', args: 'refresh PR feedback', status: 'complete' },
+        { tool: 'command_expansion', args: 'worker · pr/fix auto', status: 'complete' }
+      ] },
+      { id: 'output', phase: 'output', output: [
+        'PR loop complete for #51',
+        'CI failures remaining: 0',
+        'Actionable feedback remaining: 0',
+        'Fix passes completed: 1'
+      ] }
+    ]
+  },
+  {
     id: 'todo',
     label: '/todo',
     command: '/todo @TODO.md',

--- a/packages/web/src/content/docs/docs/reference/agents/index.mdx
+++ b/packages/web/src/content/docs/docs/reference/agents/index.mdx
@@ -15,7 +15,7 @@ Generic worker role with minimal built-in behavior. It is the default execution 
 
 ### `navigator`
 
-Owns structured multi-step workflows locally, preserves state and stop conditions, and forwards literal `<delegate>` blocks through the `command_expansion` tool when commands such as `/ship`, `/todo`, and `/ticket/dev` require delegated step execution.
+Owns structured multi-step workflows locally, preserves state and stop conditions, and forwards literal `<delegate>` blocks through the `command_expansion` tool when commands such as `/ship`, `/todo`, `/ticket/dev`, and `/loop/pr/fix` require delegated step execution.
 
 ### `planner`
 

--- a/packages/web/src/content/docs/docs/reference/agents/navigator.mdx
+++ b/packages/web/src/content/docs/docs/reference/agents/navigator.mdx
@@ -10,7 +10,7 @@ description: Orchestrator agent for structured multi-step workflows.
 ## Best for
 
 - pause-and-resume workflows
-- stepwise orchestration such as `/ship`, `/todo`, and `/ticket/dev`
+- stepwise orchestration such as `/ship`, `/todo`, `/ticket/dev`, and `/loop/pr/fix`
 - commands that mix local state handling with delegated leaf steps
 
 ## Key behavior

--- a/packages/web/src/content/docs/docs/reference/commands/index.mdx
+++ b/packages/web/src/content/docs/docs/reference/commands/index.mdx
@@ -11,7 +11,7 @@ Kompass ships workflow-oriented commands authored as explicit templates in `pack
 - Guidelines: `/learn`, `/skill/create`, `/skill/optimize`
 - Ticket: `/ticket/ask`, `/ticket/create`, `/ticket/dev`, `/ticket/plan`, `/ticket/plan-and-sync`
 - PR: `/pr/create`, `/pr/fix`, `/pr/review`, `/review`
-- Orchestration: `/dev`, `/ship`, `/todo`
+- Orchestration: `/dev`, `/ship`, `/todo`, `/loop/pr/fix`
 
 ## What makes them different
 
@@ -150,11 +150,19 @@ Creates a pull request for the current branch, including mandatory ticket resolu
 
 ### `/pr/fix`
 
-Addresses PR feedback by making fixes and responding to review threads.
+Addresses PR feedback or CI failures by making fixes and responding to review threads.
 
 - usage: `/pr/fix [pr-or-auto-or-context]`
 - arguments: optional PR ref, `auto`, or additional fix guidance
 - expected tools: `pr_load`, file-edit tools, validation commands, `question` unless `auto`, `git push`, `pr_sync`
+
+### `/loop/pr/fix`
+
+Watches PR CI and comments, then repeatedly delegates non-interactive CI and feedback fixes through `/pr/fix auto` until no actionable work remains.
+
+- usage: `/loop/pr/fix [pr-or-context]`
+- arguments: optional PR ref, CI guidance, or fix scope constraints
+- expected tools: `pr_load`, `gh pr checks --watch`, `command_expansion(pr/fix)`
 
 ### `/pr/review`
 

--- a/packages/web/src/content/docs/docs/reference/commands/loop-pr-fix.mdx
+++ b/packages/web/src/content/docs/docs/reference/commands/loop-pr-fix.mdx
@@ -1,0 +1,24 @@
+---
+title: /loop/pr/fix
+description: Watch PR CI and comments, repeatedly fixing both without approval prompts.
+---
+
+Use `/loop/pr/fix` when a PR should be advanced hands-off until both CI and review feedback are clean.
+
+```text
+/loop/pr/fix [pr-or-context]
+```
+
+## Behavior
+
+- loads the PR and stores the PR URL and number
+- watches `gh pr checks <number> --watch` until the latest checks finish
+- reloads the PR after checks finish
+- delegates actionable CI failures and PR feedback to `/pr/fix auto`
+- repeats after each push until no actionable CI failures or PR feedback remain
+- stops on failing validation, failed push, failed PR replies, or no-change feedback loops
+
+## Related
+
+- `/pr/fix`
+- `/pr/review`

--- a/packages/web/src/content/docs/docs/reference/commands/pr-fix.mdx
+++ b/packages/web/src/content/docs/docs/reference/commands/pr-fix.mdx
@@ -1,11 +1,11 @@
 ---
 title: /pr/fix
-description: Fix PR feedback with a review-first approval loop by default, then push and reply.
+description: Fix PR feedback or CI failures with a review-first approval loop by default, then push and reply.
 ---
 
 ## Purpose
 
-Use `/pr/fix` when a PR already exists and review feedback needs another implementation pass.
+Use `/pr/fix` when a PR already exists and review feedback or CI failures need another implementation pass.
 
 ## Usage
 
@@ -16,7 +16,7 @@ Use `/pr/fix` when a PR already exists and review feedback needs another impleme
 ## Typical flow
 
 - load the PR and existing review state
-- implement the requested fixes on the current branch
+- implement the requested review or CI fixes on the current branch
 - run relevant validation
 - in default mode, show the fix summary and wait for user approval before commit, push, or replies
 - skip that approval loop only with `/pr/fix auto`

--- a/packages/web/src/content/docs/docs/reference/tools/pr-load.mdx
+++ b/packages/web/src/content/docs/docs/reference/tools/pr-load.mdx
@@ -24,3 +24,4 @@ Use `pr_load` when a workflow needs one grounded PR context payload instead of s
 
 - `/pr/review`
 - `/pr/fix`
+- `/loop/pr/fix`


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Adds a hands-off PR maintenance command that watches CI and review feedback, delegates automatic fix passes, and keeps command, config, generated OpenCode output, tests, and documentation aligned.

## Checklist

### PR Loop Command
- [x] Add `/loop/pr/fix` as a navigator-led orchestration command
- [x] Define the CI watch, feedback reload, delegated auto-fix, and loop completion flow

### Command Surface
- [x] Register the command in bundled config, schema, and command definitions
- [x] Reflect CI-failure handling in `/pr/fix`

### Documentation
- [x] Document `/loop/pr/fix` in package docs, web docs, and command showcase surfaces
- [x] Include generated OpenCode command output for review

### Validation
- [x] Verify that the command resolves and renders through the command registry
- [x] Confirm that bundled command config includes `/loop/pr/fix` across packages
- [x] Check that docs describe the new CI-and-feedback loop accurately