### PR TITLE
feat: add pr/analyze subagent command

### DIFF
--- a/kompass.jsonc
+++ b/kompass.jsonc
@@ -21,6 +21,7 @@
     "merge": { "enabled": true },
     "pr/create": { "enabled": true },
     "pr/fix": { "enabled": true },
+    "pr/analyze": { "enabled": true },
     "pr/review": { "enabled": true },
     "review": { "enabled": true },
     "skill/create": { "enabled": true },

--- a/kompass.schema.json
+++ b/kompass.schema.json
@@ -62,6 +62,9 @@
         "pr/fix": {
           "$ref": "#/$defs/commandConfig"
         },
+        "pr/analyze": {
+          "$ref": "#/$defs/commandConfig"
+        },
         "pr/review": {
           "$ref": "#/$defs/commandConfig"
         },
@@ -113,6 +116,7 @@
               "merge",
               "pr/create",
               "pr/fix",
+              "pr/analyze",
               "pr/review",
               "review",
               "skill/create",
@@ -144,6 +148,7 @@
               "merge",
               "pr/create",
               "pr/fix",
+              "pr/analyze",
               "pr/review",
               "review",
               "skill/create",

--- a/packages/core/commands/index.ts
+++ b/packages/core/commands/index.ts
@@ -72,6 +72,11 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
     templatePath: "commands/pr/fix.md",
     subtask: false,
   },
+  "pr/analyze": {
+    description: "Load and filter PR review history into an actionable brief",
+    agent: "reviewer",
+    templatePath: "commands/pr/analyze.md",
+  },
   "pr/review": {
     description: "Review the current PR and publish review feedback",
     agent: "reviewer",

--- a/packages/core/commands/loop/pr/fix.md
+++ b/packages/core/commands/loop/pr/fix.md
@@ -23,12 +23,17 @@ $ARGUMENTS
 - If empty, leave `<pr-ref>` undefined and let `<%= it.config.tools.pr_load.name %>` resolve the default PR context
 - Initialize `<completed-fix-passes>` as `0`
 
-### Load PR Context
+### Delegate PR Analysis
 
-<%~ include("@load-pr", { config: it.config, ref: "<pr-ref>", result: "<pr-context>" }) %>
+<delegate agent="<%= it.config.agents.reviewer.name %>" command="<%= it.config.commands["pr/analyze"].name %>">
+<pr-ref>
 
-- Store `<pr-url>` as `<pr-context.pr.url>`
-- Store `<pr-number>` as `<pr-context.pr.number>`
+Additional context: <additional-context>
+</delegate>
+
+- Store the delegated result as `<pr-analysis>`
+- Extract `<pr-url>` from the PR_URL section of `<pr-analysis>`
+- Extract `<pr-number>` from the PR_NUMBER section of `<pr-analysis>`
 - STOP if `<pr-url>` or `<pr-number>` is unavailable
 
 ### Watch CI And Comments
@@ -41,10 +46,14 @@ $ARGUMENTS
 
 ### Reload PR Feedback
 
-Call `<%= it.config.tools.pr_load.name %>` with `<pr-url>` and store the refreshed result as `<fresh-pr-context>`.
+<delegate agent="<%= it.config.agents.reviewer.name %>" command="<%= it.config.commands["pr/analyze"].name %>">
+<pr-url>
 
-- Review `<fresh-pr-context.threads>`, `<fresh-pr-context.reviews>`, and `<fresh-pr-context.issueComments>`
-- Identify open, unresolved, actionable reviewer feedback that has not already been answered by the author or superseded by later commits
+Additional context: <additional-context>
+</delegate>
+
+- Store the refreshed result as `<fresh-pr-analysis>`
+- Use the THREADS and SUMMARY sections from `<fresh-pr-analysis>` to identify open, unresolved, actionable reviewer feedback that has not already been answered by the author or superseded by later commits
 - Combine actionable reviewer feedback and `<ci-failures>` into `<actionable-work>`
 - Store the number of actionable reviewer items as `<actionable-feedback-count>`
 - Store the number of actionable CI failures as `<actionable-ci-count>`

--- a/packages/core/commands/pr/analyze.md
+++ b/packages/core/commands/pr/analyze.md
@@ -1,0 +1,102 @@
+## Goal
+
+Load a pull request's full review history, filter out resolved and outdated threads, and return a compact actionable brief so the caller never receives stale or already-addressed feedback in its context.
+
+## Additional Context
+
+Use `<additional-context>` to focus the analysis on specific feedback categories, reviewer priorities, or CI concerns that should influence which threads are flagged as actionable.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` looks like a PR number (e.g., "123") or URL, store it as `<pr-ref>`
+- If `<arguments>` includes extra analysis guidance, scope constraints, or priorities, store it as `<additional-context>`
+- If empty, leave `<pr-ref>` undefined and let `<%= it.config.tools.pr_load.name %>` resolve the default PR context
+
+### Load PR Context
+
+<%~ include("@load-pr", { config: it.config, ref: "<pr-ref>", result: "<pr-context>" }) %>
+
+- Store `<pr-url>` as `<pr-context.pr.url>`
+- Store `<pr-number>` as `<pr-context.pr.number>`
+- Store `<pr-branch>` as `<pr-context.pr.headRefName>`
+- Store `<base-branch>` as `<pr-context.pr.baseRefName>`
+- Store `<commit-count>` as `<pr-context.pr.commitCount>`
+- STOP if `<pr-url>` or `<pr-number>` is unavailable
+
+### Filter Resolved Threads
+
+- Exclude every thread in `<pr-context.threads>` where `isResolved` is `true`
+- Exclude every thread where `isOutdated` is `true`
+- For each remaining thread, check whether the latest reply from the PR author indicates the feedback was already addressed (phrases like "Fixed", "Done", "Addressed") and a later commit in `<pr-context.pr.commits>` plausibly implements that fix
+- Move effectively-resolved threads to a `<resolved-silently>` list with a one-line reason
+- Store the remaining threads as `<actionable-threads>`
+
+### Categorize Threads
+
+For each thread in `<actionable-threads>`:
+- Classify as `critical`, `important`, `style`, `question`, or `noise`
+- Record `<comment-id>`, `<file>`, `<lines>`, `<category>`, `<suggestion>` (one-line), `<current-heading>` (`yes` or `no`)
+- Threads marked `noise` or `question` go to the `<not-fixing>` list with reasons
+
+### Partition Groups
+
+- Group actionable threads (`critical`, `important`, actionable `style`) into file-disjoint groups for parallel implementation
+- Threads sharing the same file or having cross-thread dependencies stay in the same group
+- Store the partition as `<groups>`
+
+### Output
+
+Return a single fenced markdown block with this structure:
+
+```
+PR_NUMBER: <pr-number>
+PR_BRANCH: <pr-branch>
+BASE_BRANCH: <base-branch>
+PR_URL: <pr-url>
+COMMIT_COUNT: <commit-count>
+
+SUMMARY:
+- One-line overall assessment
+- Recommended fix order: critical first, then important, then style
+- Total actionable threads: <count>
+- Total resolved-silently threads: <count>
+
+THREADS:
+- [critical] <comment-id> <file>:<lines> - <suggestion> (current-heading: yes/no)
+- [important] <comment-id> <file>:<lines> - <suggestion> (current-heading: yes/no)
+- [style] <comment-id> <file>:<lines> - <suggestion> (current-heading: yes/no)
+
+NOT_FIXING:
+- [noise] <comment-id> - <reason>
+- [question] <comment-id> - <reason>
+
+RESOLVED_SILENTLY:
+- <comment-id> - <reason>
+
+GROUPS:
+- group-1: <file-a>, <file-b>
+- group-2: <file-c>
+```
+
+If no actionable threads remain, output:
+```
+PR_NUMBER: <pr-number>
+PR_BRANCH: <pr-branch>
+BASE_BRANCH: <base-branch>
+PR_URL: <pr-url>
+COMMIT_COUNT: <commit-count>
+
+SUMMARY:
+- No actionable feedback remaining
+- Total actionable threads: 0
+
+No additional steps are required.
+```

--- a/packages/core/commands/pr/fix.md
+++ b/packages/core/commands/pr/fix.md
@@ -24,31 +24,41 @@ $ARGUMENTS
 - Otherwise, store `<execution-mode>` as `review`
 - If empty, leave `<pr-ref>` undefined and let `<%= it.config.tools.pr_load.name %>` resolve the default PR context
 
-### Load PR Context
+### Delegate PR Analysis
 
-<%~ include("@load-pr", { config: it.config, ref: "<pr-ref>", result: "<pr-context>" }) %>
+<delegate agent="<%= it.config.agents.reviewer.name %>" command="<%= it.config.commands["pr/analyze"].name %>">
+<pr-ref>
+
+Additional context: <additional-context>
+</delegate>
+
+- Store the delegated result as `<pr-analysis>`
+- Extract `<pr-number>` from the PR_NUMBER section of `<pr-analysis>`
+- Extract `<pr-branch>` from the PR_BRANCH section of `<pr-analysis>`
+- Extract `<base-branch>` from the BASE_BRANCH section of `<pr-analysis>`
+- Extract `<pr-url>` from the PR_URL section of `<pr-analysis>`
+- Extract `<commit-count>` from the COMMIT_COUNT section of `<pr-analysis>`
+- STOP if `<pr-analysis>` is unavailable or reports no actionable feedback
 
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- Run `gh pr checkout <pr-context.pr.number>` before analyzing repository files or making code changes for this PR
+- Run `gh pr checkout <pr-number>` before analyzing repository files or making code changes for this PR
 - After checkout, store the active branch as `<active-branch>`
 - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
 - Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`
 
 ### Load Changes
 
-Call `<%= it.config.tools.changes_load.name %>` with `base: <pr-context.pr.baseRefName>`, `head: <active-branch>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
+Call `<%= it.config.tools.changes_load.name %>` with `base: <base-branch>`, `head: <active-branch>`, and `depthHint: <commit-count>` only when it is a positive integer. Store as `<changes>`.
 
 ### Analyze Feedback
 
-Separate true course corrections from noise or already-resolved feedback:
-1. Review `<pr-context.threads>` for open, unresolved conversations
-2. Check `<pr-context.reviews>` for state changes (CHANGES_REQUESTED, etc.)
-3. Include any CI failures, logs, failing check names, or reproduction details provided in `<additional-context>` as actionable feedback
-4. Use `<changes>` to understand the current PR diff before deciding what to adjust
-5. Prioritize critical issues (bugs, security, broken contracts, failing required checks)
-6. Identify which files need changes
+- Use the THREADS, SUMMARY, and GROUPS sections from `<pr-analysis>` as the filtered, actionable feedback source
+- Include any CI failures, logs, failing check names, or reproduction details provided in `<additional-context>` as actionable feedback
+- Use `<changes>` to understand the current PR diff before deciding what to adjust
+- Prioritize critical issues (bugs, security, broken contracts, failing required checks)
+- Identify which files need changes
 
 Do not blindly follow every suggestion—some may lead you off course.
 
@@ -122,13 +132,13 @@ Only after commit and push succeed, reply to addressed threads:
 
 ```
 # General PR comment
-<%= it.config.tools.pr_sync.name %> refUrl="<pr-context.pr.url>" commentBody="<reply-text>"
+<%= it.config.tools.pr_sync.name %> refUrl="<pr-url>" commentBody="<reply-text>"
 
 # Reply to a specific review thread (use comment.id from threads.comments)
-<%= it.config.tools.pr_sync.name %> refUrl="<pr-context.pr.url>" replies=[{"inReplyTo": <comment-id>, "body": "<reply-text>"}]
+<%= it.config.tools.pr_sync.name %> refUrl="<pr-url>" replies=[{"inReplyTo": <comment-id>, "body": "<reply-text>"}]
 
 # Follow-up inline review comment on a specific line
-<%= it.config.tools.pr_sync.name %> refUrl="<pr-context.pr.url>" commitId="<commit-sha>" review={"comments": [{"path": "<file-path>", "line": <line-number>, "body": "<reply-text>"}]}
+<%= it.config.tools.pr_sync.name %> refUrl="<pr-url>" commitId="<commit-sha>" review={"comments": [{"path": "<file-path>", "line": <line-number>, "body": "<reply-text>"}]}
 ```
 
 Confirm which feedback was addressed and which was intentionally not followed.
@@ -138,7 +148,7 @@ Confirm which feedback was addressed and which was intentionally not followed.
 
 When waiting for approval or revision feedback, display:
 ```
-Review fixes for PR #<pr-context.pr.number>
+Review fixes for PR #<pr-number>
 
 - Changes made: <changes-count> files modified
 - Validation passing: <validation-passing>
@@ -147,7 +157,7 @@ Review fixes for PR #<pr-context.pr.number>
 
 If the workflow stops after a no-change pass, display:
 ```
-No changes made for PR #<pr-context.pr.number>
+No changes made for PR #<pr-number>
 
 - Changes made: 0 files modified
 - Validation passing: <validation-passing>
@@ -158,7 +168,7 @@ No additional steps are required.
 
 When fixes are complete, display exactly this final completion summary and stop. Do not continue with extra analysis, planning, or follow-up tasks unless the workflow is blocked or the user asked for more:
 ```
-PR fix complete for #<pr-context.pr.number>
+PR fix complete for #<pr-number>
 
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>

--- a/packages/core/kompass.jsonc
+++ b/packages/core/kompass.jsonc
@@ -21,6 +21,7 @@
     "merge": { "enabled": true },
     "pr/create": { "enabled": true },
     "pr/fix": { "enabled": true },
+    "pr/analyze": { "enabled": true },
     "pr/review": { "enabled": true },
     "review": { "enabled": true },
     "skill/create": { "enabled": true },

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -33,6 +33,7 @@ export const DEFAULT_COMMAND_NAMES = [
   "merge",
   "pr/create",
   "pr/fix",
+  "pr/analyze",
   "pr/review",
   "review",
   "skill/create",

--- a/packages/core/test/commands.test.ts
+++ b/packages/core/test/commands.test.ts
@@ -28,7 +28,7 @@ describe("resolveCommands", () => {
     const commands = await resolveCommands(process.cwd());
     const template = commands["pr/fix"]?.template ?? "";
 
-    assert.match(template, /Run `gh pr checkout <pr-context\.pr\.number>` before analyzing repository files or making code changes for this PR/);
+    assert.match(template, /Run `gh pr checkout <pr-number>` before analyzing repository files or making code changes for this PR/);
     assert.match(template, /Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`/);
     assert.doesNotMatch(template, /`<current-branch>` differs from `<pr-branch>` or `<current-head>` differs from `<pr-context\.pr\.headRefOid>`/);
   });

--- a/packages/opencode/.opencode/commands/loop/pr/fix.md
+++ b/packages/opencode/.opencode/commands/loop/pr/fix.md
@@ -28,22 +28,17 @@ $ARGUMENTS
 - If empty, leave `<pr-ref>` undefined and let `kompass_pr_load` resolve the default PR context
 - Initialize `<completed-fix-passes>` as `0`
 
-### Load PR Context
+### Delegate PR Analysis
 
-- Use `kompass_pr_load` as the source of truth for PR selection
-- If `<pr-ref>` is defined, call `kompass_pr_load` with `pr: <pr-ref>`
-- Otherwise, call `kompass_pr_load` with no arguments
-- Do not run separate git or GitHub commands just to discover the PR before calling `kompass_pr_load`
-- Store the result as `<pr-context>`
-- Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
-- Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
-- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
-- Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
-- Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
-- If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
+<delegate agent="reviewer" command="pr/analyze">
+<pr-ref>
 
-- Store `<pr-url>` as `<pr-context.pr.url>`
-- Store `<pr-number>` as `<pr-context.pr.number>`
+Additional context: <additional-context>
+</delegate>
+
+- Store the delegated result as `<pr-analysis>`
+- Extract `<pr-url>` from the PR_URL section of `<pr-analysis>`
+- Extract `<pr-number>` from the PR_NUMBER section of `<pr-analysis>`
 - STOP if `<pr-url>` or `<pr-number>` is unavailable
 
 ### Watch CI And Comments
@@ -56,10 +51,14 @@ $ARGUMENTS
 
 ### Reload PR Feedback
 
-Call `kompass_pr_load` with `<pr-url>` and store the refreshed result as `<fresh-pr-context>`.
+<delegate agent="reviewer" command="pr/analyze">
+<pr-url>
 
-- Review `<fresh-pr-context.threads>`, `<fresh-pr-context.reviews>`, and `<fresh-pr-context.issueComments>`
-- Identify open, unresolved, actionable reviewer feedback that has not already been answered by the author or superseded by later commits
+Additional context: <additional-context>
+</delegate>
+
+- Store the refreshed result as `<fresh-pr-analysis>`
+- Use the THREADS and SUMMARY sections from `<fresh-pr-analysis>` to identify open, unresolved, actionable reviewer feedback that has not already been answered by the author or superseded by later commits
 - Combine actionable reviewer feedback and `<ci-failures>` into `<actionable-work>`
 - Store the number of actionable reviewer items as `<actionable-feedback-count>`
 - Store the number of actionable CI failures as `<actionable-ci-count>`

--- a/packages/opencode/.opencode/commands/pr/analyze.md
+++ b/packages/opencode/.opencode/commands/pr/analyze.md
@@ -1,0 +1,117 @@
+---
+description: Load and filter PR review history into an actionable brief
+agent: reviewer
+---
+
+## Goal
+
+Load a pull request's full review history, filter out resolved and outdated threads, and return a compact actionable brief so the caller never receives stale or already-addressed feedback in its context.
+
+## Additional Context
+
+Use `<additional-context>` to focus the analysis on specific feedback categories, reviewer priorities, or CI concerns that should influence which threads are flagged as actionable.
+
+## Workflow
+
+### Arguments
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+### Interpret Arguments
+
+- If `<arguments>` looks like a PR number (e.g., "123") or URL, store it as `<pr-ref>`
+- If `<arguments>` includes extra analysis guidance, scope constraints, or priorities, store it as `<additional-context>`
+- If empty, leave `<pr-ref>` undefined and let `kompass_pr_load` resolve the default PR context
+
+### Load PR Context
+
+- Use `kompass_pr_load` as the source of truth for PR selection
+- If `<pr-ref>` is defined, call `kompass_pr_load` with `pr: <pr-ref>`
+- Otherwise, call `kompass_pr_load` with no arguments
+- Do not run separate git or GitHub commands just to discover the PR before calling `kompass_pr_load`
+- Store the result as `<pr-context>`
+- Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
+- Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
+- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
+- Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
+- Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
+- If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
+
+- Store `<pr-url>` as `<pr-context.pr.url>`
+- Store `<pr-number>` as `<pr-context.pr.number>`
+- Store `<pr-branch>` as `<pr-context.pr.headRefName>`
+- Store `<base-branch>` as `<pr-context.pr.baseRefName>`
+- Store `<commit-count>` as `<pr-context.pr.commitCount>`
+- STOP if `<pr-url>` or `<pr-number>` is unavailable
+
+### Filter Resolved Threads
+
+- Exclude every thread in `<pr-context.threads>` where `isResolved` is `true`
+- Exclude every thread where `isOutdated` is `true`
+- For each remaining thread, check whether the latest reply from the PR author indicates the feedback was already addressed (phrases like "Fixed", "Done", "Addressed") and a later commit in `<pr-context.pr.commits>` plausibly implements that fix
+- Move effectively-resolved threads to a `<resolved-silently>` list with a one-line reason
+- Store the remaining threads as `<actionable-threads>`
+
+### Categorize Threads
+
+For each thread in `<actionable-threads>`:
+- Classify as `critical`, `important`, `style`, `question`, or `noise`
+- Record `<comment-id>`, `<file>`, `<lines>`, `<category>`, `<suggestion>` (one-line), `<current-heading>` (`yes` or `no`)
+- Threads marked `noise` or `question` go to the `<not-fixing>` list with reasons
+
+### Partition Groups
+
+- Group actionable threads (`critical`, `important`, actionable `style`) into file-disjoint groups for parallel implementation
+- Threads sharing the same file or having cross-thread dependencies stay in the same group
+- Store the partition as `<groups>`
+
+### Output
+
+Return a single fenced markdown block with this structure:
+
+```
+PR_NUMBER: <pr-number>
+PR_BRANCH: <pr-branch>
+BASE_BRANCH: <base-branch>
+PR_URL: <pr-url>
+COMMIT_COUNT: <commit-count>
+
+SUMMARY:
+- One-line overall assessment
+- Recommended fix order: critical first, then important, then style
+- Total actionable threads: <count>
+- Total resolved-silently threads: <count>
+
+THREADS:
+- [critical] <comment-id> <file>:<lines> - <suggestion> (current-heading: yes/no)
+- [important] <comment-id> <file>:<lines> - <suggestion> (current-heading: yes/no)
+- [style] <comment-id> <file>:<lines> - <suggestion> (current-heading: yes/no)
+
+NOT_FIXING:
+- [noise] <comment-id> - <reason>
+- [question] <comment-id> - <reason>
+
+RESOLVED_SILENTLY:
+- <comment-id> - <reason>
+
+GROUPS:
+- group-1: <file-a>, <file-b>
+- group-2: <file-c>
+```
+
+If no actionable threads remain, output:
+```
+PR_NUMBER: <pr-number>
+PR_BRANCH: <pr-branch>
+BASE_BRANCH: <base-branch>
+PR_URL: <pr-url>
+COMMIT_COUNT: <commit-count>
+
+SUMMARY:
+- No actionable feedback remaining
+- Total actionable threads: 0
+
+No additional steps are required.
+```

--- a/packages/opencode/.opencode/commands/pr/fix.md
+++ b/packages/opencode/.opencode/commands/pr/fix.md
@@ -29,41 +29,41 @@ $ARGUMENTS
 - Otherwise, store `<execution-mode>` as `review`
 - If empty, leave `<pr-ref>` undefined and let `kompass_pr_load` resolve the default PR context
 
-### Load PR Context
+### Delegate PR Analysis
 
-- Use `kompass_pr_load` as the source of truth for PR selection
-- If `<pr-ref>` is defined, call `kompass_pr_load` with `pr: <pr-ref>`
-- Otherwise, call `kompass_pr_load` with no arguments
-- Do not run separate git or GitHub commands just to discover the PR before calling `kompass_pr_load`
-- Store the result as `<pr-context>`
-- Store the PR head branch as `<pr-branch>` from `<pr-context>.pr.headRefName` when it is available
-- Run `git branch --show-current` and store the trimmed result as `<current-branch>` when it is available
-- Run `git rev-parse HEAD` and store the trimmed result as `<current-head>` when it is available
-- Treat the loaded PR body, discussion, review history, and any attachments or linked artifacts returned by the loader as part of the source context
-- Review attached images, screenshots, videos, PDFs, and other linked files whenever they can affect the requested fix, review outcome, reproduction steps, or acceptance criteria
-- If any relevant attachment cannot be accessed, note that gap and continue only when the remaining PR context is still sufficient to proceed reliably
+<delegate agent="reviewer" command="pr/analyze">
+<pr-ref>
+
+Additional context: <additional-context>
+</delegate>
+
+- Store the delegated result as `<pr-analysis>`
+- Extract `<pr-number>` from the PR_NUMBER section of `<pr-analysis>`
+- Extract `<pr-branch>` from the PR_BRANCH section of `<pr-analysis>`
+- Extract `<base-branch>` from the BASE_BRANCH section of `<pr-analysis>`
+- Extract `<pr-url>` from the PR_URL section of `<pr-analysis>`
+- Extract `<commit-count>` from the COMMIT_COUNT section of `<pr-analysis>`
+- STOP if `<pr-analysis>` is unavailable or reports no actionable feedback
 
 ### Align Local Branch
 
 - If `<pr-branch>` is unavailable, STOP and report that the PR head branch could not be determined
-- Run `gh pr checkout <pr-context.pr.number>` before analyzing repository files or making code changes for this PR
+- Run `gh pr checkout <pr-number>` before analyzing repository files or making code changes for this PR
 - After checkout, store the active branch as `<active-branch>`
 - If checkout fails or times out, STOP and report that the PR branch could not be checked out locally; do not retry checkout unless the user explicitly asks
 - Do not inspect or modify local code for this PR until `<active-branch>` equals `<pr-branch>`
 
 ### Load Changes
 
-Call `kompass_changes_load` with `base: <pr-context.pr.baseRefName>`, `head: <active-branch>`, and `depthHint: <pr-context.pr.commitCount>` only when it is a positive integer. Store as `<changes>`.
+Call `kompass_changes_load` with `base: <base-branch>`, `head: <active-branch>`, and `depthHint: <commit-count>` only when it is a positive integer. Store as `<changes>`.
 
 ### Analyze Feedback
 
-Separate true course corrections from noise or already-resolved feedback:
-1. Review `<pr-context.threads>` for open, unresolved conversations
-2. Check `<pr-context.reviews>` for state changes (CHANGES_REQUESTED, etc.)
-3. Include any CI failures, logs, failing check names, or reproduction details provided in `<additional-context>` as actionable feedback
-4. Use `<changes>` to understand the current PR diff before deciding what to adjust
-5. Prioritize critical issues (bugs, security, broken contracts, failing required checks)
-6. Identify which files need changes
+- Use the THREADS, SUMMARY, and GROUPS sections from `<pr-analysis>` as the filtered, actionable feedback source
+- Include any CI failures, logs, failing check names, or reproduction details provided in `<additional-context>` as actionable feedback
+- Use `<changes>` to understand the current PR diff before deciding what to adjust
+- Prioritize critical issues (bugs, security, broken contracts, failing required checks)
+- Identify which files need changes
 
 Do not blindly follow every suggestion—some may lead you off course.
 
@@ -136,13 +136,13 @@ Only after commit and push succeed, reply to addressed threads:
 
 ```
 # General PR comment
-kompass_pr_sync refUrl="<pr-context.pr.url>" commentBody="<reply-text>"
+kompass_pr_sync refUrl="<pr-url>" commentBody="<reply-text>"
 
 # Reply to a specific review thread (use comment.id from threads.comments)
-kompass_pr_sync refUrl="<pr-context.pr.url>" replies=[{"inReplyTo": <comment-id>, "body": "<reply-text>"}]
+kompass_pr_sync refUrl="<pr-url>" replies=[{"inReplyTo": <comment-id>, "body": "<reply-text>"}]
 
 # Follow-up inline review comment on a specific line
-kompass_pr_sync refUrl="<pr-context.pr.url>" commitId="<commit-sha>" review={"comments": [{"path": "<file-path>", "line": <line-number>, "body": "<reply-text>"}]}
+kompass_pr_sync refUrl="<pr-url>" commitId="<commit-sha>" review={"comments": [{"path": "<file-path>", "line": <line-number>, "body": "<reply-text>"}]}
 ```
 
 Confirm which feedback was addressed and which was intentionally not followed.
@@ -152,7 +152,7 @@ Confirm which feedback was addressed and which was intentionally not followed.
 
 When waiting for approval or revision feedback, display:
 ```
-Review fixes for PR #<pr-context.pr.number>
+Review fixes for PR #<pr-number>
 
 - Changes made: <changes-count> files modified
 - Validation passing: <validation-passing>
@@ -161,7 +161,7 @@ Review fixes for PR #<pr-context.pr.number>
 
 If the workflow stops after a no-change pass, display:
 ```
-No changes made for PR #<pr-context.pr.number>
+No changes made for PR #<pr-number>
 
 - Changes made: 0 files modified
 - Validation passing: <validation-passing>
@@ -172,7 +172,7 @@ No additional steps are required.
 
 When fixes are complete, display exactly this final completion summary and stop. Do not continue with extra analysis, planning, or follow-up tasks unless the workflow is blocked or the user asked for more:
 ```
-PR fix complete for #<pr-context.pr.number>
+PR fix complete for #<pr-number>
 
 - Changes made: <changes-count> files modified
 - Threads resolved: <threads-resolved>

--- a/packages/opencode/.opencode/kompass.jsonc
+++ b/packages/opencode/.opencode/kompass.jsonc
@@ -37,6 +37,9 @@
     "pr/fix": {
       "enabled": true
     },
+    "pr/analyze": {
+      "enabled": true
+    },
     "pr/review": {
       "enabled": true
     },

--- a/packages/opencode/kompass.jsonc
+++ b/packages/opencode/kompass.jsonc
@@ -21,6 +21,7 @@
     "merge": { "enabled": true },
     "pr/create": { "enabled": true },
     "pr/fix": { "enabled": true },
+    "pr/analyze": { "enabled": true },
     "pr/review": { "enabled": true },
     "review": { "enabled": true },
     "skill/create": { "enabled": true },

--- a/packages/opencode/test/commands-config.test.ts
+++ b/packages/opencode/test/commands-config.test.ts
@@ -39,6 +39,7 @@ describe("applyCommandsConfig", () => {
         "pr/create",
         "pr/review",
         "pr/fix",
+        "pr/analyze",
         "skill/create",
         "skill/optimize",
         "ship",
@@ -63,6 +64,7 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       assert.equal(cfg.command!["pr/review"]?.agent, "reviewer");
+      assert.equal(cfg.command!["pr/analyze"]?.agent, "reviewer");
       assert.equal(cfg.command!["branch"]?.agent, "worker");
       assert.equal(cfg.command!["merge"]?.agent, "worker");
       assert.equal(cfg.command!["pr/create"]?.agent, "worker");
@@ -501,13 +503,13 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       const devTemplate = cfg.command!["dev"].template;
-      
+
       // Should have replaced components
       assert.match(devTemplate, /Development Flow Navigation Guide/);
       // PR Author content is now inline in pr/create, not embedded in dev
       assert.match(devTemplate, /## Goal/);
       assert.match(devTemplate, /Implement a feature or fix/);
-      
+
       assert.doesNotMatch(devTemplate, /<%/);
     });
 
@@ -519,13 +521,13 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       const prCreateTemplate = cfg.command!["pr/create"].template;
-      
+
       // Should have inline workflow content (no longer uses PR Author component)
       assert.match(prCreateTemplate, /## Goal/);
       assert.match(prCreateTemplate, /Create a pull request/);
       assert.match(prCreateTemplate, /Interpret Arguments/);
       assert.match(prCreateTemplate, /Load & Analyze Changes/);
-      
+
       assert.doesNotMatch(prCreateTemplate, /<%/);
     });
 
@@ -577,7 +579,7 @@ describe("applyCommandsConfig", () => {
 
       assert.ok(cfg.command);
       const ticketDevTemplate = cfg.command!["ticket/dev"].template;
-      
+
       // Should have replaced components
       assert.match(ticketDevTemplate, /Development Flow Navigation Guide/);
       // PR Author content is now inline in pr/create, not embedded here
@@ -637,7 +639,7 @@ describe("applyCommandsConfig", () => {
       await applyCommandsConfig(cfg as never, process.cwd());
 
       assert.ok(cfg.command);
-      
+
       const commitTemplate = cfg.command!["commit"].template;
       assert.match(commitTemplate, /pass `uncommitted: true`/);
       assert.doesNotMatch(commitTemplate, /<%/);
@@ -650,10 +652,10 @@ describe("applyCommandsConfig", () => {
       await applyCommandsConfig(cfg as never, process.cwd());
 
       assert.ok(cfg.command);
-      
+
       const commitTemplate = cfg.command!["commit"].template;
       const prCreateTemplate = cfg.command!["pr/create"].template;
-      
+
       assert.match(commitTemplate, /pass `uncommitted: true`/);
       assert.match(prCreateTemplate, /base branch/);
     });

--- a/packages/web/src/content/docs/docs/reference/commands/index.mdx
+++ b/packages/web/src/content/docs/docs/reference/commands/index.mdx
@@ -10,7 +10,7 @@ Kompass ships workflow-oriented commands authored as explicit templates in `pack
 - Workflow: `/ask`, `/branch`, `/commit`, `/commit-and-push`, `/merge`, `/rmslop`
 - Guidelines: `/learn`, `/skill/create`, `/skill/optimize`
 - Ticket: `/ticket/ask`, `/ticket/create`, `/ticket/dev`, `/ticket/plan`, `/ticket/plan-and-sync`
-- PR: `/pr/create`, `/pr/fix`, `/pr/review`, `/review`
+- PR: `/pr/create`, `/pr/fix`, `/pr/analyze`, `/pr/review`, `/review`
 - Orchestration: `/dev`, `/ship`, `/todo`, `/loop/pr/fix`
 
 ## What makes them different
@@ -154,7 +154,15 @@ Addresses PR feedback or CI failures by making fixes and responding to review th
 
 - usage: `/pr/fix [pr-or-auto-or-context]`
 - arguments: optional PR ref, `auto`, or additional fix guidance
-- expected tools: `pr_load`, file-edit tools, validation commands, `question` unless `auto`, `git push`, `pr_sync`
+- expected tools: `command_expansion(pr/analyze)`, file-edit tools, validation commands, `question` unless `auto`, `git push`, `pr_sync`
+
+### `/pr/analyze`
+
+Loads and filters PR review history into an actionable brief, excluding resolved and outdated threads.
+
+- usage: `/pr/analyze [pr-or-context]`
+- arguments: optional PR ref or analysis guidance
+- expected tools: `pr_load`
 
 ### `/loop/pr/fix`
 

--- a/packages/web/src/content/docs/docs/reference/commands/loop-pr-fix.mdx
+++ b/packages/web/src/content/docs/docs/reference/commands/loop-pr-fix.mdx
@@ -11,9 +11,9 @@ Use `/loop/pr/fix` when a PR should be advanced hands-off until both CI and revi
 
 ## Behavior
 
-- loads the PR and stores the PR URL and number
+- delegates PR analysis to `/pr/analyze` to load and filter review history
 - watches `gh pr checks <number> --watch` until the latest checks finish
-- reloads the PR after checks finish
+- reloads PR feedback via `/pr/analyze` after checks finish
 - delegates actionable CI failures and PR feedback to `/pr/fix auto`
 - repeats after each push until no actionable CI failures or PR feedback remain
 - stops on failing validation, failed push, failed PR replies, or no-change feedback loops
@@ -21,4 +21,5 @@ Use `/loop/pr/fix` when a PR should be advanced hands-off until both CI and revi
 ## Related
 
 - `/pr/fix`
+- `/pr/analyze`
 - `/pr/review`

--- a/packages/web/src/content/docs/docs/reference/commands/pr-analyze.mdx
+++ b/packages/web/src/content/docs/docs/reference/commands/pr-analyze.mdx
@@ -1,0 +1,33 @@
+---
+title: /pr/analyze
+description: Load and filter PR review history into an actionable brief.
+---
+
+## Purpose
+
+Use `/pr/analyze` to load a pull request's full review history, filter out resolved and outdated threads, and return a compact actionable brief. The full thread history stays in the subagent's isolated context window — only filtered, actionable feedback reaches the caller.
+
+## Usage
+
+```text
+/pr/analyze [pr-or-context]
+```
+
+## Typical flow
+
+- load the PR and full review history via `pr_load`
+- filter out resolved and outdated threads
+- detect effectively-resolved threads (author reply + later commit)
+- categorize remaining threads by severity (critical, important, style, noise, question)
+- partition actionable threads into file-disjoint groups for parallel implementation
+- return a structured markdown brief with PR metadata, thread list, and group partition
+
+## Common tools
+
+- `pr_load`
+
+## Related
+
+- `/pr/fix`
+- `/loop/pr/fix`
+- `/pr/review`

--- a/packages/web/src/content/docs/docs/reference/commands/pr-fix.mdx
+++ b/packages/web/src/content/docs/docs/reference/commands/pr-fix.mdx
@@ -15,7 +15,7 @@ Use `/pr/fix` when a PR already exists and review feedback or CI failures need a
 
 ## Typical flow
 
-- load the PR and existing review state
+- delegate PR analysis to `/pr/analyze` to load and filter review history into an actionable brief
 - implement the requested review or CI fixes on the current branch
 - run relevant validation
 - in default mode, show the fix summary and wait for user approval before commit, push, or replies
@@ -24,7 +24,7 @@ Use `/pr/fix` when a PR already exists and review feedback or CI failures need a
 
 ## Common tools
 
-- `pr_load`
+- `command_expansion(pr/analyze)`
 - `question`
 - `apply_patch`
 - `pr_sync`


### PR DESCRIPTION
## Summary
- Adds `pr/analyze` subcommand that delegates PR loading and thread filtering to a `reviewer` subagent with isolated context (`subtask: true`), preventing the main agent from re-parsing stale resolved threads on multi-round PRs
- Updates `pr/fix` and `loop/pr/fix` to delegate analysis to `pr/analyze` instead of inline `pr_load` parsing
- Syncs registration (`commands/index.ts`, `lib/config.ts`), schema (`kompass.schema.json`), bundled config (all three `kompass.jsonc`), tests, and web docs

#### Test plan
- [x] `bun run compile` — generates `packages/opencode/.opencode/commands/pr/analyze.md`
- [x] `bun run typecheck` — only pre-existing unrelated error in `packages/opencode/config.ts`
- [x] `bun run test` — 55 pass, 0 fail