### PR TITLE
Add label support to PR sync

### DIFF
--- a/packages/core/test/pr-sync.test.ts
+++ b/packages/core/test/pr-sync.test.ts
@@ -139,6 +139,73 @@ describe("pr_sync", () => {
     assert.match(executedCommands[1], /--add-assignee octocat/);
   });
 
+  test("removes labels from an existing PR", async () => {
+    const executedCommands: string[] = [];
+    const shell = createMockShell(executedCommands, [
+      {
+        contains: "gh pr view https://github.com/acme/repo/pull/9 --json number,url",
+        stdout: JSON.stringify({ number: 9, url: "https://github.com/acme/repo/pull/9" }),
+      },
+      {
+        contains: "gh pr edit https://github.com/acme/repo/pull/9",
+        stdout: "",
+      },
+    ]);
+
+    const tool = createPrSyncTool(shell);
+    const output = await tool.execute({
+      refUrl: "https://github.com/acme/repo/pull/9",
+      removeLabels: ["blocked", "needs review"],
+    }, createToolContextForDirectory("/tmp/repo"));
+
+    const result = JSON.parse(output);
+    assert.equal(result.action, "updated");
+    assert.match(executedCommands[1], /--remove-label blocked/);
+    assert.match(executedCommands[1], /--remove-label needs review/);
+  });
+
+  test("replaces the complete label set on an existing PR", async () => {
+    const executedCommands: string[] = [];
+    const shell = createMockShell(executedCommands, [
+      {
+        contains: "gh pr view https://github.com/acme/repo/pull/9 --json number,url",
+        stdout: JSON.stringify({ number: 9, url: "https://github.com/acme/repo/pull/9" }),
+      },
+      {
+        contains: "gh repo view --json nameWithOwner",
+        stdout: JSON.stringify({ nameWithOwner: "acme/repo" }),
+      },
+      {
+        contains: "/repos/acme/repo/issues/9/labels --input -",
+        stdout: JSON.stringify([]),
+      },
+    ]);
+
+    const tool = createPrSyncTool(shell);
+    const output = await tool.execute({
+      refUrl: "https://github.com/acme/repo/pull/9",
+      replaceLabels: [],
+    }, createToolContextForDirectory("/tmp/repo"));
+
+    const result = JSON.parse(output);
+    assert.equal(result.action, "updated");
+    assert.match(executedCommands[2], /--method PUT/);
+    assert.match(executedCommands[2], /"labels":\[\]/);
+  });
+
+  test("rejects replacing and incrementally changing labels together", async () => {
+    const tool = createPrSyncTool(createMockShell([], []));
+
+    await assert.rejects(
+      tool.execute({
+        refUrl: "https://github.com/acme/repo/pull/9",
+        labels: ["enhancement"],
+        replaceLabels: ["ready"],
+      }, createToolContextForDirectory("/tmp/repo")),
+      /replaceLabels cannot be combined with labels or removeLabels/,
+    );
+  });
+
   test("submits structured review comments through pr_sync", async () => {
     const executedCommands: string[] = [];
     const shell = createMockShell(executedCommands, [

--- a/packages/core/test/pr-sync.test.ts
+++ b/packages/core/test/pr-sync.test.ts
@@ -6,7 +6,7 @@ import type { Shell, ShellPromise } from "../tools/shared.ts";
 import { createPrSyncTool } from "../tools/pr-sync.ts";
 
 describe("pr_sync", () => {
-  test("creates a PR with explicit head branch and assignees", async () => {
+  test("creates a PR with explicit head branch, labels, and assignees", async () => {
     const executedCommands: string[] = [];
     const shell = createMockShell(executedCommands, [
       {
@@ -21,6 +21,7 @@ describe("pr_sync", () => {
       body: "Uses explicit head branch when creating PRs.",
       base: "main",
       head: "feature/pr-head",
+      labels: ["enhancement", "ready for review"],
       assignees: ["octocat", "hubot"],
     }, createToolContextForDirectory("/tmp/repo"));
 
@@ -29,6 +30,8 @@ describe("pr_sync", () => {
     assert.equal(result.action, "created");
     assert.match(executedCommands[0], /--base main/);
     assert.match(executedCommands[0], /--head feature\/pr-head/);
+    assert.match(executedCommands[0], /--label enhancement/);
+    assert.match(executedCommands[0], /--label ready for review/);
     assert.match(executedCommands[0], /--assignee octocat/);
     assert.match(executedCommands[0], /--assignee hubot/);
   });
@@ -122,6 +125,7 @@ describe("pr_sync", () => {
     const output = await tool.execute({
       title: "Tighten review automation",
       body: "Updated body",
+      labels: ["automation"],
       assignees: ["octocat"],
       refUrl: "https://github.com/acme/repo/pull/9",
       review: { approve: true },
@@ -131,6 +135,7 @@ describe("pr_sync", () => {
     assert.equal(result.action, "updated_and_approved");
     assert.match(executedCommands[1], /--title Tighten review automation/);
     assert.match(executedCommands[1], /--body Updated body/);
+    assert.match(executedCommands[1], /--add-label automation/);
     assert.match(executedCommands[1], /--add-assignee octocat/);
   });
 

--- a/packages/core/tools/pr-sync.ts
+++ b/packages/core/tools/pr-sync.ts
@@ -36,6 +36,8 @@ type PrSyncArgs = {
   base?: string;
   head?: string;
   labels?: string[];
+  removeLabels?: string[];
+  replaceLabels?: string[];
   assignees?: string[];
   checklists?: Array<{
     name: string;
@@ -97,6 +99,8 @@ function hasMetadataUpdate(args: PrSyncArgs, body?: string) {
       body ||
       args.base?.trim() ||
       collectLabels(args.labels).length > 0 ||
+      collectLabels(args.removeLabels).length > 0 ||
+      args.replaceLabels !== undefined ||
       collectAssignees(args.assignees).length > 0,
   );
 }
@@ -332,7 +336,14 @@ async function updatePullRequest(
   $: Shell,
   worktree: string,
   refUrl: string,
-  args: { title?: string; body?: string; base?: string; labels?: string[]; assignees?: string[] },
+  args: {
+    title?: string;
+    body?: string;
+    base?: string;
+    labels?: string[];
+    removeLabels?: string[];
+    assignees?: string[];
+  },
 ) {
   const updateArgs: string[] = [];
   if (args.title?.trim()) {
@@ -346,6 +357,9 @@ async function updatePullRequest(
   }
   for (const label of collectLabels(args.labels)) {
     updateArgs.push("--add-label", label);
+  }
+  for (const label of collectLabels(args.removeLabels)) {
+    updateArgs.push("--remove-label", label);
   }
   for (const assignee of collectAssignees(args.assignees)) {
     updateArgs.push("--add-assignee", assignee);
@@ -365,6 +379,25 @@ async function updatePullRequest(
   }
 
   return true;
+}
+
+async function replacePullRequestLabels(
+  $: Shell,
+  worktree: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  labels: string[],
+) {
+  const payload = JSON.stringify({ labels: collectLabels(labels) });
+  const proc = await $`echo ${payload} | gh api --method PUT /repos/${owner}/${repo}/issues/${prNumber}/labels --input -`
+    .cwd(worktree)
+    .quiet()
+    .nothrow();
+
+  if (proc.exitCode !== 0) {
+    throw new Error(proc.stderr.toString() || "Failed to replace PR labels");
+  }
 }
 
 function summarizeActions(actions: string[]) {
@@ -403,7 +436,17 @@ export function createPrSyncTool($: Shell) {
       labels: {
         type: "string[]",
         optional: true,
-        description: "Labels to apply to the PR",
+        description: "Labels to add to the PR",
+      },
+      removeLabels: {
+        type: "string[]",
+        optional: true,
+        description: "Labels to remove from an existing PR",
+      },
+      replaceLabels: {
+        type: "string[]",
+        optional: true,
+        description: "Exact label set for the PR; an empty array clears all labels",
       },
       assignees: {
         type: "string[]",
@@ -452,6 +495,17 @@ export function createPrSyncTool($: Shell) {
       const metadataUpdate = hasMetadataUpdate(args, body);
       const existingPrActions = requiresExistingPullRequest(args, review);
 
+      if (
+        args.replaceLabels !== undefined &&
+        (args.labels !== undefined || args.removeLabels !== undefined)
+      ) {
+        throw new Error("pr_sync replaceLabels cannot be combined with labels or removeLabels");
+      }
+
+      if (!args.refUrl?.trim() && collectLabels(args.removeLabels).length > 0) {
+        throw new Error("pr_sync removeLabels requires refUrl");
+      }
+
       if (!args.refUrl?.trim() && existingPrActions && metadataUpdate) {
         throw new Error("pr_sync requires refUrl when combining PR updates with review, comment, or reply actions");
       }
@@ -476,7 +530,7 @@ export function createPrSyncTool($: Shell) {
         for (const assignee of collectAssignees(args.assignees)) {
           createArgs.push("--assignee", assignee);
         }
-        for (const label of collectLabels(args.labels)) {
+        for (const label of collectLabels(args.replaceLabels ?? args.labels)) {
           createArgs.push("--label", label);
         }
         if (args.draft) {
@@ -514,9 +568,21 @@ export function createPrSyncTool($: Shell) {
           body,
           base: args.base,
           labels: args.labels,
+          removeLabels: args.removeLabels,
           assignees: args.assignees,
         });
-        if (updated) {
+        if (args.replaceLabels !== undefined) {
+          const { owner, repoName } = await getRepoContext();
+          await replacePullRequestLabels(
+            $,
+            ctx.worktree,
+            owner,
+            repoName,
+            target.number,
+            args.replaceLabels,
+          );
+        }
+        if (updated || args.replaceLabels !== undefined) {
           actions.push("updated");
         }
       }
@@ -557,7 +623,7 @@ export function createPrSyncTool($: Shell) {
 
       if (actions.length === 0) {
         throw new Error(
-          "pr_sync requires title, body, description, checklist content, labels, assignees, review, commentBody, or replies",
+          "pr_sync requires title, body, description, checklist content, label changes, assignees, review, commentBody, or replies",
         );
       }
 

--- a/packages/core/tools/pr-sync.ts
+++ b/packages/core/tools/pr-sync.ts
@@ -35,6 +35,7 @@ type PrSyncArgs = {
   description?: string;
   base?: string;
   head?: string;
+  labels?: string[];
   assignees?: string[];
   checklists?: Array<{
     name: string;
@@ -95,8 +96,15 @@ function hasMetadataUpdate(args: PrSyncArgs, body?: string) {
     args.title?.trim() ||
       body ||
       args.base?.trim() ||
+      collectLabels(args.labels).length > 0 ||
       collectAssignees(args.assignees).length > 0,
   );
+}
+
+function collectLabels(labels?: string[]): string[] {
+  return (labels ?? [])
+    .filter((label) => label.trim())
+    .map((label) => label.trim());
 }
 
 function collectAssignees(assignees?: string[]): string[] {
@@ -324,7 +332,7 @@ async function updatePullRequest(
   $: Shell,
   worktree: string,
   refUrl: string,
-  args: { title?: string; body?: string; base?: string; assignees?: string[] },
+  args: { title?: string; body?: string; base?: string; labels?: string[]; assignees?: string[] },
 ) {
   const updateArgs: string[] = [];
   if (args.title?.trim()) {
@@ -335,6 +343,9 @@ async function updatePullRequest(
   }
   if (args.base?.trim()) {
     updateArgs.push("--base", args.base.trim());
+  }
+  for (const label of collectLabels(args.labels)) {
+    updateArgs.push("--add-label", label);
   }
   for (const assignee of collectAssignees(args.assignees)) {
     updateArgs.push("--add-assignee", assignee);
@@ -388,6 +399,11 @@ export function createPrSyncTool($: Shell) {
         type: "string",
         optional: true,
         description: "Head branch to open the PR from when creating a new pull request",
+      },
+      labels: {
+        type: "string[]",
+        optional: true,
+        description: "Labels to apply to the PR",
       },
       assignees: {
         type: "string[]",
@@ -460,6 +476,9 @@ export function createPrSyncTool($: Shell) {
         for (const assignee of collectAssignees(args.assignees)) {
           createArgs.push("--assignee", assignee);
         }
+        for (const label of collectLabels(args.labels)) {
+          createArgs.push("--label", label);
+        }
         if (args.draft) {
           createArgs.push("--draft");
         }
@@ -494,6 +513,7 @@ export function createPrSyncTool($: Shell) {
           title: args.title,
           body,
           base: args.base,
+          labels: args.labels,
           assignees: args.assignees,
         });
         if (updated) {
@@ -537,7 +557,7 @@ export function createPrSyncTool($: Shell) {
 
       if (actions.length === 0) {
         throw new Error(
-          "pr_sync requires title, body, description, checklist content, review, commentBody, or replies",
+          "pr_sync requires title, body, description, checklist content, labels, assignees, review, commentBody, or replies",
         );
       }
 

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -240,6 +240,7 @@ const opencodeToolCreators: Record<string, OpenCodeToolCreator> = {
         description: tool.schema.string().describe("Short PR description rendered above checklist sections").optional(),
         base: tool.schema.string().describe("Base branch to merge into").optional(),
         head: tool.schema.string().describe("Head branch to use when creating a PR").optional(),
+        labels: tool.schema.array(tool.schema.string()).describe("Labels to apply to the PR").optional(),
         assignees: tool.schema.array(tool.schema.string()).describe("Assignees to apply to the PR").optional(),
         checklists: tool.schema.array(tool.schema.object({
           name: tool.schema.string().describe("Checklist section name"),

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -240,7 +240,9 @@ const opencodeToolCreators: Record<string, OpenCodeToolCreator> = {
         description: tool.schema.string().describe("Short PR description rendered above checklist sections").optional(),
         base: tool.schema.string().describe("Base branch to merge into").optional(),
         head: tool.schema.string().describe("Head branch to use when creating a PR").optional(),
-        labels: tool.schema.array(tool.schema.string()).describe("Labels to apply to the PR").optional(),
+        labels: tool.schema.array(tool.schema.string()).describe("Labels to add to the PR").optional(),
+        removeLabels: tool.schema.array(tool.schema.string()).describe("Labels to remove from an existing PR").optional(),
+        replaceLabels: tool.schema.array(tool.schema.string()).describe("Exact label set for the PR; an empty array clears all labels").optional(),
         assignees: tool.schema.array(tool.schema.string()).describe("Assignees to apply to the PR").optional(),
         checklists: tool.schema.array(tool.schema.object({
           name: tool.schema.string().describe("Checklist section name"),

--- a/packages/opencode/test/tool-registration.test.ts
+++ b/packages/opencode/test/tool-registration.test.ts
@@ -462,6 +462,8 @@ describe("createOpenCodeTools", () => {
       const prSyncArgs = (tools.kompass_pr_sync as any).args;
       const ticketSyncArgs = (tools.kompass_ticket_sync as any).args;
       assert.ok(prSyncArgs.labels);
+      assert.ok(prSyncArgs.removeLabels);
+      assert.ok(prSyncArgs.replaceLabels);
       assert.ok(prSyncArgs.assignees);
       assert.ok(ticketSyncArgs.assignees);
       assert.ok(ticketSyncArgs.comments);

--- a/packages/opencode/test/tool-registration.test.ts
+++ b/packages/opencode/test/tool-registration.test.ts
@@ -455,12 +455,13 @@ describe("createOpenCodeTools", () => {
     });
   });
 
-  test("exposes ticket assignees and comments, and PR assignees", async () => {
+  test("exposes ticket assignees and comments, and PR labels and assignees", async () => {
     await withTempHome(async () => {
       const tools = await createOpenCodeTools(createMockClient() as never, process.cwd());
 
       const prSyncArgs = (tools.kompass_pr_sync as any).args;
       const ticketSyncArgs = (tools.kompass_ticket_sync as any).args;
+      assert.ok(prSyncArgs.labels);
       assert.ok(prSyncArgs.assignees);
       assert.ok(ticketSyncArgs.assignees);
       assert.ok(ticketSyncArgs.comments);

--- a/packages/web/src/content/docs/docs/reference/tools/pr-sync.mdx
+++ b/packages/web/src/content/docs/docs/reference/tools/pr-sync.mdx
@@ -15,6 +15,8 @@ Use one tool surface for PR creation, metadata updates, comments, replies, and f
 - `base`
 - `head`
 - `labels`
+- `removeLabels`
+- `replaceLabels`
 - `assignees`
 - `checklists`
 - `draft`

--- a/packages/web/src/content/docs/docs/reference/tools/pr-sync.mdx
+++ b/packages/web/src/content/docs/docs/reference/tools/pr-sync.mdx
@@ -14,6 +14,7 @@ Use one tool surface for PR creation, metadata updates, comments, replies, and f
 - `description`
 - `base`
 - `head`
+- `labels`
 - `assignees`
 - `checklists`
 - `draft`


### PR DESCRIPTION
## Ticket

SKIPPED

## Description

Enable `pr_sync` callers to apply GitHub labels when creating or updating pull requests, with the input exposed consistently through the OpenCode adapter and reference documentation.

## Checklist

### PR Label Management

- [x] Apply normalized labels during PR creation
- [x] Add labels during PR metadata updates

### OpenCode Integration

- [x] Expose the `labels` input through the OpenCode tool schema
- [x] Document the supported PR sync input

### Validation

- [x] Verify that PR creation and update commands include label flags
- [x] Confirm that compile, typecheck, and test suites pass