### PR TITLE
Add configurable GitHub and Jira ticket providers

### DIFF
--- a/kompass.jsonc
+++ b/kompass.jsonc
@@ -47,6 +47,7 @@
   },
 
   "tools": {
+    "provider": "github",
     "changes_load": { "enabled": true },
     "pr_load": { "enabled": true },
     "pr_load_review": { "enabled": true },

--- a/kompass.schema.json
+++ b/kompass.schema.json
@@ -218,6 +218,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["github", "jira"],
+          "default": "github",
+          "description": "Ticket provider used by ticket_load and ticket_sync"
+        },
         "changes_load": {
           "$ref": "#/$defs/toolConfig"
         },

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -29,6 +29,15 @@ export { createPrLoadReviewTool } from "./tools/pr-load-review.ts";
 export { createPrSyncTool } from "./tools/pr-sync.ts";
 export { createTicketLoadTool } from "./tools/ticket-load.ts";
 export { createTicketSyncTool } from "./tools/ticket-sync.ts";
+export { createTicketProviderChain } from "./tools/provider/factory.ts";
+export { createGitHubProvider } from "./tools/provider/github.ts";
+export { createJiraProvider } from "./tools/provider/jira.ts";
+export { TicketProviderName } from "./tools/provider/interface.ts";
+export type {
+  TicketLoadArgs,
+  TicketProvider,
+  TicketSyncArgs,
+} from "./tools/provider/interface.ts";
 export type {
   Shell,
   ShellPromise,

--- a/packages/core/kompass.jsonc
+++ b/packages/core/kompass.jsonc
@@ -47,6 +47,7 @@
   },
 
   "tools": {
+    "provider": "github",
     "changes_load": { "enabled": true },
     "pr_load": { "enabled": true },
     "pr_load_review": { "enabled": true },

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { TicketProviderName } from "../tools/provider/interface.ts";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export interface AgentDefinition {
@@ -158,6 +160,7 @@ export interface KompassConfig {
     enabled?: string[];
   };
   tools?: {
+    provider?: TicketProviderName;
     changes_load?: ToolConfig;
     pr_load?: ToolConfig;
     pr_load_review?: ToolConfig;
@@ -220,6 +223,7 @@ export interface MergedKompassConfig {
     planner: AgentDefinition;
   };
   tools: {
+    provider: TicketProviderName;
     changes_load: ToolConfig;
     pr_load: ToolConfig;
     pr_load_review: ToolConfig;
@@ -700,6 +704,7 @@ export function mergeWithDefaults(
       planner: { ...defaultAgentPlanner, ...plannerOverrides },
     },
     tools: {
+      provider: config?.tools?.provider ?? TicketProviderName.GitHub,
       changes_load: { ...defaultToolConfig.changes_load, ...config?.tools?.changes_load },
       pr_load: { ...defaultToolConfig.pr_load, ...config?.tools?.pr_load },
       pr_load_review: {

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { loadKompassConfig, mergeWithDefaults } from "../lib/config.ts";
+import { TicketProviderName } from "../tools/provider/interface.ts";
 
 const originalHome = process.env.HOME;
 
@@ -229,6 +230,11 @@ describe("config loading", () => {
 });
 
 describe("object-based config", () => {
+  test("defaults to GitHub and supports Jira as the ticket provider", () => {
+    assert.equal(mergeWithDefaults(null).tools.provider, TicketProviderName.GitHub);
+    assert.equal(mergeWithDefaults({ tools: { provider: TicketProviderName.Jira } }).tools.provider, TicketProviderName.Jira);
+  });
+
   test("merges Navigator defaults and validates limits", () => {
     const defaults = mergeWithDefaults(null);
     assert.deepEqual(defaults.adapters.opencode.navigator, {

--- a/packages/core/test/provider.test.ts
+++ b/packages/core/test/provider.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { createTicketProviderChain } from "../tools/provider/factory.ts";
+import { textFromAdf } from "../tools/provider/jira.ts";
+import { TicketProviderName } from "../tools/provider/interface.ts";
+import type { Shell } from "../tools/shared.ts";
+
+const shell = (() => {
+  throw new Error("The provider test does not execute shell commands");
+}) as unknown as Shell;
+
+describe("ticket provider chain", () => {
+  test("orders providers according to the configured preference", () => {
+    const github = createTicketProviderChain(shell, TicketProviderName.GitHub);
+    const jira = createTicketProviderChain(shell, TicketProviderName.Jira);
+
+    assert.equal(github.name, TicketProviderName.GitHub);
+    assert.equal(jira.name, TicketProviderName.Jira);
+    assert.equal(github.canLoad("owner/repo#12"), true);
+    assert.equal(jira.canLoad("PROJ-12"), true);
+  });
+
+  test("routes recognizable references to a provider in the chain", () => {
+    const chain = createTicketProviderChain(shell, TicketProviderName.GitHub);
+
+    assert.equal(chain.canSync("https://github.com/owner/repo/issues/12"), true);
+    assert.equal(chain.canSync("https://example.atlassian.net/browse/PROJ-12"), true);
+    assert.equal(chain.canSync(), true);
+  });
+
+  test("extracts text nodes from Jira ADF descriptions", () => {
+    assert.equal(textFromAdf({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        content: [{ type: "text", text: "Implement Jira support" }],
+      }],
+    }), "Implement Jira support");
+  });
+});

--- a/packages/core/tools/index.ts
+++ b/packages/core/tools/index.ts
@@ -11,14 +11,18 @@ import { createPrSyncTool } from "./pr-sync.ts";
 import { createTicketLoadTool } from "./ticket-load.ts";
 import { createTicketSyncTool } from "./ticket-sync.ts";
 import type { Shell, ToolDefinition } from "./shared.ts";
+import { TicketProviderName } from "./provider/interface.ts";
 
-const toolCreators: Record<string, ($: Shell, projectRoot: string) => ToolDefinition> = {
+const toolCreators: Record<
+  string,
+  ($: Shell, projectRoot: string, provider: TicketProviderName) => ToolDefinition
+> = {
   changes_load: ($) => createChangesLoadTool($),
   pr_load: ($) => createPrLoadTool($),
   pr_load_review: ($) => createPrLoadReviewTool($),
   pr_sync: ($) => createPrSyncTool($),
-  ticket_sync: ($) => createTicketSyncTool($),
-  ticket_load: ($) => createTicketLoadTool($),
+  ticket_sync: ($, _projectRoot, provider) => createTicketSyncTool($, provider),
+  ticket_load: ($, _projectRoot, provider) => createTicketLoadTool($, provider),
 };
 
 export async function createTools($: Shell, projectRoot: string) {
@@ -30,7 +34,7 @@ export async function createTools($: Shell, projectRoot: string) {
   for (const toolName of getEnabledToolNames(config.tools)) {
     const creator = toolCreators[toolName];
     if (creator) {
-      tools[getConfiguredToolName(config.tools, toolName)] = creator($, projectRoot);
+      tools[getConfiguredToolName(config.tools, toolName)] = creator($, projectRoot, config.tools.provider);
     }
   }
 

--- a/packages/core/tools/provider/factory.ts
+++ b/packages/core/tools/provider/factory.ts
@@ -1,0 +1,47 @@
+import type { Shell, ToolExecutionContext } from "../shared.ts";
+import { createGitHubProvider } from "./github.ts";
+import { createJiraProvider } from "./jira.ts";
+import { TicketProviderName } from "./interface.ts";
+import type {
+  TicketLoadArgs,
+  TicketProvider,
+  TicketSyncArgs,
+} from "./interface.ts";
+
+class TicketProviderChain implements TicketProvider {
+  readonly name: TicketProviderName;
+  private readonly providers: TicketProvider[];
+
+  constructor(providers: TicketProvider[], preferred: TicketProviderName) {
+    this.providers = providers;
+    this.name = preferred;
+  }
+
+  canLoad(source: string) {
+    return this.providers.some((provider) => provider.canLoad(source));
+  }
+
+  canSync(refUrl?: string) {
+    return this.providers.some((provider) => provider.canSync(refUrl));
+  }
+
+  async load(args: TicketLoadArgs, context: ToolExecutionContext) {
+    const provider = this.providers.find((candidate) => candidate.canLoad(args.source))
+      ?? this.providers.find((candidate) => candidate.name === TicketProviderName.GitHub);
+    if (!provider) throw new Error(`No ticket provider can load source: ${args.source}`);
+    return provider.load(args, context);
+  }
+
+  async sync(args: TicketSyncArgs, context: ToolExecutionContext) {
+    const provider = this.providers.find((candidate) => candidate.canSync(args.refUrl));
+    if (!provider) throw new Error(`No ticket provider can sync reference: ${args.refUrl}`);
+    return provider.sync(args, context);
+  }
+}
+
+export function createTicketProviderChain($: Shell, preferred: TicketProviderName): TicketProvider {
+  const github = createGitHubProvider($);
+  const jira = createJiraProvider();
+  const providers = preferred === TicketProviderName.Jira ? [jira, github] : [github, jira];
+  return new TicketProviderChain(providers, preferred);
+}

--- a/packages/core/tools/provider/github.ts
+++ b/packages/core/tools/provider/github.ts
@@ -1,0 +1,111 @@
+import { access, readFile } from "node:fs/promises";
+
+import {
+  loadRepoName,
+  parseIssueReference,
+  resolveInputPath,
+  stringifyJson,
+  type Shell,
+  type ToolExecutionContext,
+} from "../shared.ts";
+import {
+  renderTicketBody,
+  type TicketLoadArgs,
+  type TicketProvider,
+  type TicketSyncArgs,
+} from "./interface.ts";
+import { TicketProviderName } from "./interface.ts";
+
+const issueJsonKeys = "number,title,body,url,state,labels,assignees,author";
+
+async function fileExists(filePath: string) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function collectValues(values?: string[]) {
+  return (values ?? []).filter((value) => value.trim()).map((value) => value.trim());
+}
+
+export function createGitHubProvider($: Shell): TicketProvider {
+  return {
+    name: TicketProviderName.GitHub,
+    canLoad(source) {
+      return Boolean(parseIssueReference(source));
+    },
+    canSync(refUrl) {
+      return !refUrl || Boolean(parseIssueReference(refUrl));
+    },
+    async load(args: TicketLoadArgs, context: ToolExecutionContext) {
+      const source = args.source.trim();
+      const issue = parseIssueReference(source);
+
+      if (issue) {
+        const repo = issue.repo ?? (await loadRepoName($, context.worktree));
+        const proc = await $`gh issue view ${issue.number} --repo ${repo} --json ${issueJsonKeys}`
+          .cwd(context.worktree).quiet().nothrow();
+        if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || "Failed to load issue");
+
+        const comments = args.comments
+          ? await $`gh issue view ${issue.number} --repo ${repo} --comments --json comments`
+              .cwd(context.worktree).quiet().nothrow()
+          : undefined;
+        return stringifyJson({
+          kind: "github-issue",
+          repo,
+          issue: JSON.parse(proc.text()),
+          comments: comments?.exitCode === 0 ? JSON.parse(comments.text()).comments : undefined,
+        });
+      }
+
+      const filePath = resolveInputPath(context.directory, source);
+      if (await fileExists(filePath)) {
+        return stringifyJson({ kind: "file", path: filePath, body: await readFile(filePath, "utf8") });
+      }
+      return stringifyJson({ kind: "text", body: args.source });
+    },
+    async sync(args: TicketSyncArgs, context: ToolExecutionContext) {
+      const body = renderTicketBody(args);
+      const labels = collectValues(args.labels);
+      const assignees = collectValues(args.assignees);
+      const comments = collectValues(args.comments);
+
+      if (args.refUrl) {
+        if (!body && !args.title?.trim() && !labels.length && !assignees.length && !comments.length) {
+          throw new Error("ticket_sync requires title, body, description, checklist content, labels, or comments when updating an issue");
+        }
+        if (body || args.title?.trim() || labels.length || assignees.length) {
+          const editArgs = [
+            ...(args.title?.trim() ? ["--title", args.title.trim()] : []),
+            ...(body ? ["--body", body] : []),
+            ...labels.flatMap((label) => ["--add-label", label]),
+            ...assignees.flatMap((assignee) => ["--add-assignee", assignee]),
+          ];
+          const proc = await $`gh issue edit ${args.refUrl} ${editArgs}`
+            .cwd(context.worktree).quiet().nothrow();
+          if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || "Failed to update issue");
+        }
+        for (const comment of comments) await postComment($, context.worktree, args.refUrl, comment);
+        return stringifyJson({ url: args.refUrl });
+      }
+
+      if (!args.title?.trim()) throw new Error("ticket_sync requires title when creating an issue");
+      if (!body) throw new Error("ticket_sync requires body, description, or checklist content when creating an issue");
+      const proc = await $`gh issue create --title ${args.title.trim()} --body ${body} ${labels.flatMap((label) => ["--label", label])} ${assignees.flatMap((assignee) => ["--assignee", assignee])}`
+        .cwd(context.worktree).quiet().nothrow();
+      if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || "Failed to create issue");
+      const url = proc.text().trim();
+      for (const comment of comments) await postComment($, context.worktree, url, comment);
+      return stringifyJson({ url });
+    },
+  };
+}
+
+async function postComment($: Shell, worktree: string, issueRef: string, body: string) {
+  const proc = await $`gh issue comment ${issueRef} --body ${body}`.cwd(worktree).quiet().nothrow();
+  if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || "Failed to post issue comment");
+}

--- a/packages/core/tools/provider/interface.ts
+++ b/packages/core/tools/provider/interface.ts
@@ -1,0 +1,55 @@
+import type { ToolExecutionContext } from "../shared.ts";
+
+export const TicketProviderName = {
+  GitHub: "github",
+  Jira: "jira",
+} as const;
+
+export type TicketProviderName = (typeof TicketProviderName)[keyof typeof TicketProviderName];
+
+export type TicketLoadArgs = {
+  source: string;
+  comments?: boolean;
+};
+
+export type TicketSyncArgs = {
+  title?: string;
+  body?: string;
+  description?: string;
+  labels?: string[];
+  assignees?: string[];
+  checklists?: Array<{
+    name: string;
+    items: Array<{
+      name: string;
+      completed: boolean;
+    }>;
+  }>;
+  projectKey?: string;
+  refUrl?: string;
+  comments?: string[];
+};
+
+export interface TicketProvider {
+  readonly name: TicketProviderName;
+  canLoad(source: string): boolean;
+  canSync(refUrl?: string): boolean;
+  load(args: TicketLoadArgs, context: ToolExecutionContext): Promise<string>;
+  sync(args: TicketSyncArgs, context: ToolExecutionContext): Promise<string>;
+}
+
+export function renderTicketBody(args: TicketSyncArgs) {
+  if (args.body?.trim()) return args.body.trim();
+
+  const sections: string[] = [];
+  if (args.description?.trim()) sections.push(args.description.trim());
+
+  for (const checklist of args.checklists ?? []) {
+    const items = checklist.items
+      .map((item) => `- [${item.completed ? "x" : " "}] ${item.name}`)
+      .join("\n");
+    if (items) sections.push(`### ${checklist.name}\n\n${items}`);
+  }
+
+  return sections.join("\n\n").trim() || undefined;
+}

--- a/packages/core/tools/provider/jira.ts
+++ b/packages/core/tools/provider/jira.ts
@@ -1,0 +1,255 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { stringifyJson, type ToolExecutionContext } from "../shared.ts";
+import {
+  renderTicketBody,
+  type TicketLoadArgs,
+  type TicketProvider,
+  type TicketSyncArgs,
+} from "./interface.ts";
+import { TicketProviderName } from "./interface.ts";
+
+type JiraConfig = {
+  baseUrl: string;
+  email: string;
+  apiToken: string;
+  projectKey?: string;
+};
+
+type JiraContext = Pick<ToolExecutionContext, "directory">;
+
+async function loadEnv(filePath: string): Promise<Record<string, string>> {
+  try {
+    const content = await readFile(filePath, "utf8");
+    return Object.fromEntries(
+      content
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith("#"))
+        .map((line) => {
+          const separator = line.indexOf("=");
+          return separator < 0
+            ? [line, ""]
+            : [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
+        }),
+    );
+  } catch {
+    return {};
+  }
+}
+
+async function getJiraConfig(context: JiraContext): Promise<JiraConfig> {
+  const env = await loadEnv(path.join(context.directory, ".opencode/tools/jira/.env"));
+  const baseUrl = process.env.JIRA_BASE_URL || env.JIRA_BASE_URL;
+  const email = process.env.JIRA_EMAIL || env.JIRA_EMAIL;
+  const apiToken = process.env.JIRA_API_TOKEN || env.JIRA_API_TOKEN;
+  const projectKey = process.env.JIRA_PROJECT_KEY || env.JIRA_PROJECT_KEY;
+
+  if (!baseUrl || !email || !apiToken) {
+    throw new Error(
+      "Missing JIRA_BASE_URL, JIRA_EMAIL, or JIRA_API_TOKEN. Configure them in .opencode/tools/jira/.env or the environment.",
+    );
+  }
+
+  return { baseUrl: baseUrl.replace(/\/+$/, ""), email, apiToken, projectKey };
+}
+
+function authHeader(config: JiraConfig) {
+  return `Basic ${Buffer.from(`${config.email}:${config.apiToken}`).toString("base64")}`;
+}
+
+async function requestJira(
+  config: JiraConfig,
+  endpoint: string,
+  options: RequestInit = {},
+) {
+  const headers = new Headers(options.headers);
+  headers.set("Accept", "application/json");
+  headers.set("Authorization", authHeader(config));
+  if (options.body !== undefined) headers.set("Content-Type", "application/json");
+
+  const response = await fetch(`${config.baseUrl}/rest/api/3${endpoint}`, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Jira API ${response.status}: ${await response.text()}`);
+  }
+
+  const text = await response.text();
+  return text ? JSON.parse(text) : {};
+}
+
+export function isJiraIssueInput(input: string) {
+  try {
+    const url = new URL(input);
+    return /\/browse\/[^/]+-\d+/.test(url.pathname);
+  } catch {
+    return /^[A-Z][A-Z0-9_]*-\d+$/i.test(input.trim());
+  }
+}
+
+export function parseJiraIssueKey(input: string) {
+  try {
+    const parts = new URL(input).pathname.split("/").filter(Boolean);
+    return parts[parts.length - 1] ?? "";
+  } catch {
+    return input.trim();
+  }
+}
+
+export function textFromAdf(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return null;
+  const node = value as { text?: unknown; content?: unknown[] };
+  if (typeof node.text === "string") return node.text;
+  const content = node.content;
+  if (!Array.isArray(content)) return null;
+  return content.map((item) => textFromAdf(item)).filter(Boolean).join("") || null;
+}
+
+function toAdf(text: string) {
+  return {
+    type: "doc",
+    version: 1,
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+async function saveAttachments(
+  config: JiraConfig,
+  attachments: Array<{ id?: string; filename?: string; content?: string }>,
+  context: JiraContext,
+) {
+  const directory = path.resolve(context.directory, ".opencode/files");
+  await mkdir(directory, { recursive: true });
+
+  return Promise.all(attachments.map(async (attachment) => {
+    if (!attachment.content || !attachment.id) return { ...attachment, skipped: true };
+    const response = await fetch(attachment.content, {
+      headers: { Authorization: authHeader(config) },
+    });
+    if (!response.ok) return { ...attachment, skipped: true, reason: `download failed ${response.status}` };
+
+    const filename = (attachment.filename ?? attachment.id).replace(/[^A-Za-z0-9._-]+/g, "-");
+    const storedName = `jira-${attachment.id}-${filename}`;
+    await writeFile(path.join(directory, storedName), Buffer.from(await response.arrayBuffer()));
+    return { ...attachment, relativePath: path.join(".opencode/files", storedName) };
+  }));
+}
+
+async function loadJiraTicket(source: string, context: JiraContext, includeComments = false) {
+  if (!isJiraIssueInput(source)) {
+    throw new Error("Unsupported Jira ticket source. Pass a full Jira issue URL or an issue key like PROJ-123.");
+  }
+
+  const config = await getJiraConfig(context);
+  const key = parseJiraIssueKey(source);
+  const issue = await requestJira(
+    config,
+    `/issue/${encodeURIComponent(key)}?fields=summary,description,labels,assignee,reporter,attachment,comment,created,updated,issuetype,status,priority`,
+  );
+  const fields = issue.fields ?? {};
+
+  return stringifyJson({
+    kind: "jira-issue",
+    source: "jira",
+    key,
+    url: `${config.baseUrl}/browse/${key}`,
+    title: fields.summary ?? null,
+    description: textFromAdf(fields.description),
+    issueType: fields.issuetype?.name ?? null,
+    status: fields.status?.name ?? null,
+    priority: fields.priority?.name ?? null,
+    labels: fields.labels ?? [],
+    assignee: fields.assignee ?? null,
+    reporter: fields.reporter ?? null,
+    attachments: await saveAttachments(config, fields.attachment ?? [], context),
+    comments: includeComments ? fields.comment?.comments ?? [] : undefined,
+    createdAt: fields.created ?? null,
+    updatedAt: fields.updated ?? null,
+  });
+}
+
+async function syncJiraTicket(args: TicketSyncArgs, context: JiraContext) {
+  const config = await getJiraConfig(context);
+  const body = renderTicketBody(args);
+  const labels = (args.labels ?? []).map((label) => label.trim()).filter(Boolean);
+  const assignees = (args.assignees ?? []).map((assignee) => assignee.trim()).filter(Boolean);
+
+  if (assignees.length > 1) {
+    throw new Error("Jira supports one assignee per issue; pass a single Jira account ID");
+  }
+
+  if (args.refUrl) {
+    if (!isJiraIssueInput(args.refUrl)) {
+      throw new Error("Unsupported Jira ticket reference. Pass a full Jira issue URL or an issue key.");
+    }
+
+    const key = parseJiraIssueKey(args.refUrl);
+    const fields: Record<string, unknown> = {};
+    if (args.title?.trim()) fields.summary = args.title.trim();
+    if (body) fields.description = toAdf(body);
+    if (args.labels) fields.labels = labels;
+    if (assignees[0]) fields.assignee = { accountId: assignees[0] };
+    if (!Object.keys(fields).length && !args.comments?.some((comment) => comment.trim())) {
+      throw new Error("ticket_sync requires title, body, description, labels, or comments when updating a Jira issue");
+    }
+    if (Object.keys(fields).length) {
+      await requestJira(config, `/issue/${encodeURIComponent(key)}`, {
+        method: "PUT",
+        body: JSON.stringify({ fields }),
+      });
+    }
+    for (const comment of args.comments ?? []) {
+      if (comment.trim()) {
+        await requestJira(config, `/issue/${encodeURIComponent(key)}/comment`, {
+          method: "POST",
+          body: JSON.stringify({ body: toAdf(comment.trim()) }),
+        });
+      }
+    }
+    return stringifyJson({ source: "jira", key, url: `${config.baseUrl}/browse/${key}` });
+  }
+
+  if (!args.title?.trim()) throw new Error("ticket_sync requires title when creating a Jira issue");
+  if (!body) throw new Error("ticket_sync requires body or description when creating a Jira issue");
+  const projectKey = args.projectKey ?? config.projectKey;
+  if (!projectKey) throw new Error("Missing Jira project key. Set JIRA_PROJECT_KEY or pass projectKey.");
+
+  const issue = await requestJira(config, "/issue", {
+    method: "POST",
+    body: JSON.stringify({
+      fields: {
+        project: { key: projectKey },
+        summary: args.title.trim(),
+        description: toAdf(body),
+        issuetype: { name: "Task" },
+        ...(args.labels ? { labels } : {}),
+        ...(assignees[0] ? { assignee: { accountId: assignees[0] } } : {}),
+      },
+    }),
+  });
+  const key = issue.key;
+  for (const comment of args.comments ?? []) {
+    if (comment.trim()) {
+      await requestJira(config, `/issue/${encodeURIComponent(key)}/comment`, {
+        method: "POST",
+        body: JSON.stringify({ body: toAdf(comment.trim()) }),
+      });
+    }
+  }
+  return stringifyJson({ source: "jira", key, id: issue.id, url: `${config.baseUrl}/browse/${key}` });
+}
+
+export function createJiraProvider(): TicketProvider {
+  return {
+    name: TicketProviderName.Jira,
+    canLoad: isJiraIssueInput,
+    canSync: (refUrl) => !refUrl || isJiraIssueInput(refUrl),
+    load: (args: TicketLoadArgs, context) => loadJiraTicket(args.source, context, args.comments),
+    sync: syncJiraTicket,
+  };
+}

--- a/packages/core/tools/ticket-load.ts
+++ b/packages/core/tools/ticket-load.ts
@@ -1,42 +1,17 @@
-import { access, readFile } from "node:fs/promises";
+import type { Shell, ToolDefinition, ToolExecutionContext } from "./shared.ts";
+import { createTicketProviderChain } from "./provider/factory.ts";
+import { TicketProviderName, type TicketLoadArgs } from "./provider/interface.ts";
 
-import {
-  loadRepoName,
-  parseIssueReference,
-  resolveInputPath,
-  stringifyJson,
-  type Shell,
-  type ToolDefinition,
-  type ToolExecutionContext,
-} from "./shared.ts";
-
-const issueJsonKeys = [
-  "number",
-  "title",
-  "body",
-  "url",
-  "state",
-  "labels",
-  "assignees",
-  "author",
-].join(",");
-
-async function fileExists(filePath: string) {
-  try {
-    await access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function createTicketLoadTool($: Shell) {
+export function createTicketLoadTool($: Shell, provider: TicketProviderName = TicketProviderName.GitHub) {
+  const chain = createTicketProviderChain($, provider);
   return {
-    description: "Load a ticket from GitHub, file, or text",
+    description:
+      provider === TicketProviderName.Jira ? "Load a Jira ticket by URL or key" : "Load a ticket from GitHub, file, or text",
     args: {
       source: {
         type: "string",
-        description: "Issue URL, repo#id, #id, file path, or raw text",
+        description:
+          provider === TicketProviderName.Jira ? "Jira issue URL or key" : "Issue URL, repo#id, #id, file path, or raw text",
       },
       comments: {
         type: "boolean",
@@ -44,56 +19,8 @@ export function createTicketLoadTool($: Shell) {
         description: "Include issue comments",
       },
     },
-    async execute(args: { source: string; comments?: boolean }, ctx: ToolExecutionContext) {
-      const source = args.source.trim();
-      const issue = parseIssueReference(source);
-
-      if (issue) {
-        const repo = issue.repo ?? (await loadRepoName($, ctx.worktree));
-        const proc = await $`gh issue view ${issue.number} --repo ${repo} --json ${issueJsonKeys}`
-          .cwd(ctx.worktree)
-          .quiet()
-          .nothrow();
-
-        if (proc.exitCode !== 0) {
-          throw new Error(proc.stderr.toString() || "Failed to load issue");
-        }
-
-        const info = JSON.parse(proc.text());
-        const comments = args.comments
-          ? await $`gh issue view ${issue.number} --repo ${repo} --comments --json comments`
-              .cwd(ctx.worktree)
-              .quiet()
-              .nothrow()
-          : undefined;
-
-        return stringifyJson({
-          kind: "github-issue",
-          repo,
-          issue: info,
-          comments:
-            comments?.exitCode === 0
-              ? JSON.parse(comments.text()).comments
-              : undefined,
-        });
-      }
-
-      const filePath = resolveInputPath(ctx.directory, source);
-      if (await fileExists(filePath)) {
-        return stringifyJson({
-          kind: "file",
-          path: filePath,
-          body: await readFile(filePath, "utf8"),
-        });
-      }
-
-      return stringifyJson({
-        kind: "text",
-        body: args.source,
-      });
+    async execute(args: TicketLoadArgs, ctx: ToolExecutionContext) {
+      return chain.load(args, ctx);
     },
-  } satisfies ToolDefinition<{
-    source: string;
-    comments?: boolean;
-  }>;
+  } satisfies ToolDefinition<TicketLoadArgs>;
 }

--- a/packages/core/tools/ticket-sync.ts
+++ b/packages/core/tools/ticket-sync.ts
@@ -1,95 +1,13 @@
-import {
-  stringifyJson,
-  type Shell,
-  type ToolDefinition,
-  type ToolExecutionContext,
-} from "./shared.ts";
+import type { Shell, ToolDefinition, ToolExecutionContext } from "./shared.ts";
+import { createTicketProviderChain } from "./provider/factory.ts";
+import { TicketProviderName, type TicketSyncArgs } from "./provider/interface.ts";
 
-type TicketSyncArgs = {
-  title?: string;
-  body?: string;
-  description?: string;
-  labels?: string[];
-  assignees?: string[];
-  checklists?: Array<{
-    name: string;
-    items: Array<{
-      name: string;
-      completed: boolean;
-    }>;
-  }>;
-  refUrl?: string;
-  comments?: string[];
-};
+export function createTicketSyncTool($: Shell, provider: TicketProviderName = TicketProviderName.GitHub) {
+  const chain = createTicketProviderChain($, provider);
 
-function renderTicketBody(args: TicketSyncArgs) {
-  if (args.body?.trim()) {
-    return args.body.trim();
-  }
-
-  const sections: string[] = [];
-
-  if (args.description?.trim()) {
-    sections.push(args.description.trim());
-  }
-
-  for (const checklist of args.checklists ?? []) {
-    const items = checklist.items
-      .map((item) => `- [${item.completed ? "x" : " "}] ${item.name}`)
-      .join("\n");
-
-    if (!items) {
-      continue;
-    }
-
-    sections.push(`### ${checklist.name}\n\n${items}`);
-  }
-
-  const body = sections.join("\n\n").trim();
-  return body || undefined;
-}
-
-function collectLabels(labels?: string[]): string[] {
-  return (labels ?? [])
-    .filter((label) => label.trim())
-    .map((label) => label.trim());
-}
-
-function collectAssignees(assignees?: string[]): string[] {
-  return (assignees ?? [])
-    .filter((assignee) => assignee.trim())
-    .map((assignee) => assignee.trim());
-}
-
-function hasMetadataUpdate(args: TicketSyncArgs, body?: string) {
-  return Boolean(
-    args.title?.trim() ||
-      body ||
-      collectLabels(args.labels).length > 0 ||
-      collectAssignees(args.assignees).length > 0,
-  );
-}
-
-async function postIssueComment($: Shell, worktree: string, issueRef: string, body: string) {
-  const proc = await $`gh issue comment ${issueRef} --body ${body}`
-    .cwd(worktree)
-    .quiet()
-    .nothrow();
-
-  if (proc.exitCode !== 0) {
-    throw new Error(proc.stderr.toString() || "Failed to post issue comment");
-  }
-}
-
-function collectComments(comments?: string[]): string[] {
-  return (comments ?? [])
-    .filter((comment) => comment.trim())
-    .map((comment) => comment.trim());
-}
-
-export function createTicketSyncTool($: Shell) {
   return {
-    description: "Create or update a GitHub issue",
+    description:
+      provider === TicketProviderName.Jira ? "Create or update a Jira issue" : "Create or update a GitHub issue",
     args: {
       title: { type: "string", optional: true, description: "Issue title" },
       body: {
@@ -127,72 +45,14 @@ export function createTicketSyncTool($: Shell) {
         optional: true,
         description: "Optional issue comments to post",
       },
+      projectKey: {
+        type: "string",
+        optional: true,
+        description: "Jira project key for issue creation",
+      },
     },
-    async execute(args: TicketSyncArgs, ctx: ToolExecutionContext) {
-      const body = renderTicketBody(args);
-      const labels = collectLabels(args.labels);
-      const assignees = collectAssignees(args.assignees);
-      const comments = collectComments(args.comments);
-
-      if (args.refUrl) {
-        if (!hasMetadataUpdate(args, body) && comments.length === 0) {
-          throw new Error("ticket_sync requires title, body, description, checklist content, labels, or comments when updating an issue");
-        }
-
-        if (hasMetadataUpdate(args, body)) {
-          const editArgs = [
-            ...(args.title?.trim() ? ["--title", args.title.trim()] : []),
-            ...(body ? ["--body", body] : []),
-            ...labels.flatMap((label) => ["--add-label", label]),
-            ...assignees.flatMap((assignee) => ["--add-assignee", assignee]),
-          ];
-          const proc = await $`gh issue edit ${args.refUrl} ${editArgs}`
-            .cwd(ctx.worktree)
-            .quiet()
-            .nothrow();
-
-          if (proc.exitCode !== 0) {
-            throw new Error(proc.stderr.toString() || "Failed to update issue");
-          }
-        }
-
-        for (const comment of comments) {
-          await postIssueComment($, ctx.worktree, args.refUrl, comment);
-        }
-
-        return stringifyJson({
-          url: args.refUrl,
-        });
-      }
-
-      if (!args.title?.trim()) {
-        throw new Error("ticket_sync requires title when creating an issue");
-      }
-
-      if (!body) {
-        throw new Error("ticket_sync requires body, description, or checklist content when creating an issue");
-      }
-
-      const labelArgs = labels.flatMap((label) => ["--label", label]);
-      const assigneeArgs = assignees.flatMap((assignee) => ["--assignee", assignee]);
-      const proc = await $`gh issue create --title ${args.title.trim()} --body ${body} ${labelArgs} ${assigneeArgs}`
-        .cwd(ctx.worktree)
-        .quiet()
-        .nothrow();
-
-      if (proc.exitCode !== 0) {
-        throw new Error(proc.stderr.toString() || "Failed to create issue");
-      }
-
-      const url = proc.text().trim();
-
-      for (const comment of comments) {
-        await postIssueComment($, ctx.worktree, url, comment);
-      }
-
-      return stringifyJson({
-        url,
-      });
+    execute(args: TicketSyncArgs, context: ToolExecutionContext) {
+      return chain.sync(args, context);
     },
   } satisfies ToolDefinition<TicketSyncArgs>;
 }

--- a/packages/opencode/.opencode/kompass.jsonc
+++ b/packages/opencode/.opencode/kompass.jsonc
@@ -101,6 +101,7 @@
     }
   },
   "tools": {
+    "provider": "github",
     "changes_load": {
       "enabled": true
     },

--- a/packages/opencode/cache.ts
+++ b/packages/opencode/cache.ts
@@ -1,6 +1,7 @@
 import {
   getConfiguredAgentNames,
   getConfiguredCommandNames,
+  getConfiguredToolNames,
   loadKompassConfig,
   mergeWithDefaults,
   type AgentName,
@@ -51,9 +52,14 @@ export function loadConfiguredNames(projectRoot: string): Promise<ConfiguredName
     const config = await loadMergedKompassConfig(projectRoot);
     return {
       tools: Object.fromEntries(
-        Object.entries(config.tools).map(([toolName, toolConfig]) => [
+        Object.entries(getConfiguredToolNames(config.tools)).map(([toolName, toolConfig]) => [
           toolName,
-          { name: getConfiguredOpenCodeToolName(toolName, toolConfig.name) },
+          {
+            name: getConfiguredOpenCodeToolName(
+              toolName,
+              toolConfig.name === toolName ? undefined : toolConfig.name,
+            ),
+          },
         ]),
       ) as Record<ToolName, { name: string }>,
       commands: getConfiguredCommandNames(config.commands),

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -278,8 +278,8 @@ const opencodeToolCreators: Record<string, OpenCodeToolCreator> = {
       execute: (args, context) => definition.execute(args, context),
     });
   },
-  ticket_sync(_: PluginInput["client"], __: MergedKompassConfig, _projectRoot: string, shell: Shell) {
-    const definition = createTicketSyncTool(shell);
+  ticket_sync(_: PluginInput["client"], config: MergedKompassConfig, _projectRoot: string, shell: Shell) {
+    const definition = createTicketSyncTool(shell, config.tools.provider);
     return tool({
       description: definition.description,
       args: {
@@ -297,12 +297,13 @@ const opencodeToolCreators: Record<string, OpenCodeToolCreator> = {
         })).describe("Checklist sections rendered as markdown").optional(),
         refUrl: tool.schema.string().describe("Optional issue URL to update").optional(),
         comments: tool.schema.array(tool.schema.string()).describe("Optional issue comments to post").optional(),
+        projectKey: tool.schema.string().describe("Jira project key for issue creation").optional(),
       },
       execute: (args, context) => definition.execute(args, context),
     });
   },
-  ticket_load(_: PluginInput["client"], __: MergedKompassConfig, _projectRoot: string, shell: Shell) {
-    const definition = createTicketLoadTool(shell);
+  ticket_load(_: PluginInput["client"], config: MergedKompassConfig, _projectRoot: string, shell: Shell) {
+    const definition = createTicketLoadTool(shell, config.tools.provider);
     return tool({
       description: definition.description,
       args: {

--- a/packages/opencode/scripts/compile.ts
+++ b/packages/opencode/scripts/compile.ts
@@ -14,6 +14,7 @@ import YAML from "yaml";
 import {
   getConfiguredAgentNames,
   getConfiguredCommandNames,
+  getConfiguredToolNames,
   getEnabledToolNames,
   loadKompassConfig,
   mergeWithDefaults,
@@ -52,9 +53,14 @@ async function main() {
   const config = mergeWithDefaults(userConfig);
   const enabledTools = getEnabledToolNames(config.tools, config.adapters.opencode.navigator.enabled);
   const configuredToolNames = Object.fromEntries(
-    Object.entries(config.tools).map(([toolName, toolConfig]) => [
+    Object.entries(getConfiguredToolNames(config.tools)).map(([toolName, toolConfig]) => [
       toolName,
-      { name: getConfiguredOpenCodeToolName(toolName, toolConfig.name) },
+      {
+        name: getConfiguredOpenCodeToolName(
+          toolName,
+          toolConfig.name === toolName ? undefined : toolConfig.name,
+        ),
+      },
     ]),
   );
   const names = {
@@ -141,13 +147,16 @@ async function main() {
       Object.keys(resolvedAgents).map((name) => [name, { enabled: true }]),
     ),
     tools: Object.fromEntries(
-      enabledTools.map((toolName) => [
+      [
+        ["provider", config.tools.provider],
+        ...enabledTools.map((toolName) => [
         toolName,
         {
           enabled: true,
           ...(config.tools[toolName].name ? { name: config.tools[toolName].name } : {}),
         },
-      ]),
+        ]),
+      ],
     ),
     defaults: config.defaults,
     adapters: config.adapters,

--- a/packages/web/src/content/docs/docs/config/overview.mdx
+++ b/packages/web/src/content/docs/docs/config/overview.mdx
@@ -29,6 +29,16 @@ Shared render-time guidance, including:
 - `prApprove`
 - `validation`
 
+### `tools.provider`
+
+Selects the provider used by the built-in `ticket_load` and `ticket_sync` tools.
+
+- `tools.provider`: `github` (default) or `jira`
+
+When using Jira, configure `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, and optionally `JIRA_PROJECT_KEY` in `.opencode/tools/jira/.env` or the process environment.
+
+The built-in ticket tools are backed by a provider chain. The configured provider is preferred for new tickets, while recognizable GitHub or Jira references are routed to the matching provider.
+
 ### `commands`
 
 Controls command availability, template overrides, and adapter-facing command names.
@@ -69,6 +79,27 @@ Adapter-specific configuration. Today this includes:
 ## Tool alias example
 
 You can keep bundled surfaces enabled but expose them under custom adapter-facing names. OpenCode tool defaults use `kompass_<tool>`, such as `kompass_ticket_load`; command and agent defaults use their config keys. Built-in command, component, and agent templates read resolved names from render config values like `<%= it.config.tools.ticket_load.name %>`.
+
+To use Jira through the built-in ticket tools:
+
+```jsonc
+{
+  "tools": {
+    "provider": "jira"
+  }
+}
+```
+
+The existing disable-and-override flow remains available when a project needs its own ticket tools:
+
+```jsonc
+{
+  "tools": {
+    "ticket_load": { "enabled": false },
+    "ticket_sync": { "enabled": false }
+  }
+}
+```
 
 ```jsonc
 {

--- a/packages/web/src/content/docs/docs/reference/tools/ticket-load.mdx
+++ b/packages/web/src/content/docs/docs/reference/tools/ticket-load.mdx
@@ -1,11 +1,11 @@
 ---
 title: ticket_load
-description: Load a ticket from GitHub, a file path, or raw text.
+description: Load a ticket from the configured GitHub or Jira provider.
 ---
 
 ## Purpose
 
-Normalize ticket input so planning and implementation flows can start from the same shape.
+Normalize ticket input so planning and implementation flows can start from the same shape. GitHub is the default provider; Jira accepts an issue key such as `PROJ-123` or a Jira issue URL.
 
 ## Inputs
 

--- a/packages/web/src/content/docs/docs/reference/tools/ticket-sync.mdx
+++ b/packages/web/src/content/docs/docs/reference/tools/ticket-sync.mdx
@@ -1,11 +1,15 @@
 ---
 title: ticket_sync
-description: Create or update a GitHub issue with structured checklist support.
+description: Create or update a ticket in the configured GitHub or Jira provider.
 ---
 
 ## Purpose
 
 Use one tool surface for issue creation, issue updates, and ticket comments.
+
+GitHub is the default provider. Set `tools.provider` to `jira` to use Jira, and pass `projectKey` when creating an issue if `JIRA_PROJECT_KEY` is not configured.
+
+Jira supports one assignee per issue; use a Jira account ID when passing `assignees`.
 
 ## Notable inputs
 
@@ -17,6 +21,7 @@ Use one tool surface for issue creation, issue updates, and ticket comments.
 - `checklists`
 - `refUrl`
 - `comments`
+- `projectKey` (Jira)
 
 ## Useful for
 


### PR DESCRIPTION
## Ticket
https://github.com/kompassdev/kompass/issues/118

## Description
Introduce a provider architecture for the built-in ticket tools so projects can use GitHub by default or Jira through configuration. Add Jira loading and synchronization with environment-based credentials, preserve GitHub behavior, and document the configuration and tool inputs.

## Checklist

### Provider Configuration
- [x] Configure GitHub as the default ticket provider
- [x] Allow projects to select Jira through `tools.provider`

### Ticket Operations
- [x] Route recognizable GitHub and Jira references to the matching provider
- [x] Support Jira issue loading, creation, updates, comments, and attachments

### Project Integration
- [x] Wire provider selection through core tools and the OpenCode adapter
- [x] Document Jira setup and ticket tool inputs

### Validation
- [ ] Verify provider ordering and reference routing tests pass
- [ ] Confirm bundled configuration and generated adapter output stay in sync